### PR TITLE
Improve error for DAG with cycles

### DIFF
--- a/src/ploomber/exceptions.py
+++ b/src/ploomber/exceptions.py
@@ -81,6 +81,18 @@ class DAGSpecInvalidError(Exception):
     pass
 
 
+class DAGCycle(Exception):
+    """
+    Raised when a DAG is defined with cycles.
+    """
+
+    def __init__(self):
+        error_message = """
+        Failed to process DAG because it contains cycles.
+        """
+        super().__init__(error_message)
+
+
 class SpecValidationError(Exception):
     """
     Raised when failing to validate a spec


### PR DESCRIPTION
This PR introduces a better error-handling of [NetworkXUnfeasible](https://networkx.org/documentation/stable/reference/exceptions.html#networkx.NetworkXUnfeasible) to raise a custom [`DAGCycle`](https://github.com/ploomber/ploomber/compare/master...arturomf94:feat/dag-cycle-error?expand=1#diff-eb7359cc30e050c11c5416ed81b5ddfc50621ee92c113e94937b33207e3253a6R1094-R1100) exception whenever a DAG with cycles is defined.

A test has been added to [test_dag.py](https://github.com/ploomber/ploomber/compare/master...arturomf94:feat/dag-cycle-error?expand=1#diff-eb7359cc30e050c11c5416ed81b5ddfc50621ee92c113e94937b33207e3253a6R1094-R1100).

Closes: https://github.com/ploomber/ploomber/issues/291