### PR TITLE
Fixed contact link to contact@ploomber.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 * [Join us on Slack](http://community.ploomber.io)
 * [Newsletter](https://www.getrevue.co/profile/ploomber)
-* [Contact the development team](https://forms.gle/Xf9h1Q2TGoSk15NEA)
+* [Contact the development team](mailto:contact@ploomber.io)
 
 ## Resources
 


### PR DESCRIPTION
I have changed the contact link to contact@ploomber.io with a mailto tag.
This is according this issue. https://github.com/ploomber/ploomber/issues/362

Let me know if there is any issue.
I would like you to consider this for Hacktoberfest.
Thanks!