### PR TITLE
Add pre-push git hook to run flake8

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""
+A hook script to verify what is about to be pushed.  Called by "git
+push" after it has checked the remote status, but before anything has been
+pushed.  If this script exits with a non-zero status nothing will be pushed.
+
+In its current implementation, this script runs flake8 on the code and will
+stop with exit code 1 if it finds any linting errors.
+"""
+import subprocess
+import sys
+
+
+def main():
+    print("Running flake8")
+    out = subprocess.run(["flake8"])
+    if out.returncode == 1:
+        print("Please correct the linting errors")
+        sys.exit(1)
+    print("flake8 ran successfully")
+
+
+if __name__ == '__main__':
+    main()

--- a/tasks.py
+++ b/tasks.py
@@ -6,6 +6,7 @@ import platform
 from pathlib import Path
 import base64
 from invoke import task
+import shutil
 
 _IS_WINDOWS = platform.system() == 'Windows'
 _PY_DEFAULT_VERSION = '3.9'
@@ -117,3 +118,14 @@ def test(c, report=False):
     c.run('pytest --cov ploomber ' + ('--cov-report html' if report else ''),
           pty=True)
     c.run('flake8')
+
+
+@task
+def install_git_hook(c):
+    """Install a pre-push git hook to local repo
+    """
+    path = Path('.git/hooks/pre-push.sample')
+    if path.is_file():
+        path.unlink()
+    shutil.copy('githooks/pre-push', '.git/hooks/')
+    print('pre-push hook installed')


### PR DESCRIPTION
Add a new invoke command install_git_hook to install the new hook
in the local .git/hooks directory. This hook will enforce flake8
returns 0 errors and warnings whenever a "git push" is run.

Issue: https://github.com/ploomber/ploomber/issues/372

Testing Done:

```
(base) bibhash@pop-os:~/Work/ploomber$ invoke install-git-hook
pre-push hook installed
```

```
(base) bibhash@pop-os:~/Work/ploomber$ git push -f origin
Running flake8
./tasks.py:126:20: E225 missing whitespace around operator
./tasks.py:131:1: W293 blank line contains whitespace
./tasks.py:135:1: W391 blank line at end of file
Please correct the linting errors
error: failed to push some refs to 'github.com:bibhashthakur/ploomber.git'
```

```
(base) bibhash@pop-os:~/Work/ploomber$ git push -f origin
Running flake8
flake8 ran successfully
Enumerating objects: 7, done.
Counting objects: 100% (7/7), done.
Delta compression using up to 12 threads
Compressing objects: 100% (4/4), done.
Writing objects: 100% (5/5), 1.07 KiB | 1.07 MiB/s, done.
Total 5 (delta 2), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To github.com:bibhashthakur/ploomber.git
 + a0451006...770a8f71 add-invoke-configure-git-hook -> add-invoke-configure-git-hook (forced update)
```