### PR TITLE
create a deepcopy of TaskSpec init params

### DIFF
--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -2,7 +2,7 @@
 Create Tasks from dictionaries
 """
 from functools import partial
-from copy import copy
+from copy import copy, deepcopy
 from pathlib import Path
 from collections.abc import MutableMapping, Mapping
 import platform
@@ -169,9 +169,8 @@ class TaskSpec(MutableMapping):
                  project_root,
                  lazy_import=False,
                  reload=False):
-        # FIXME: make sure data and meta are immutable structures
-        self.data = data
-        self.meta = meta
+        self.data = deepcopy(data)
+        self.meta = deepcopy(meta)
         self.project_root = project_root
         self.lazy_import = lazy_import
 

--- a/tests/spec/test_taskspec.py
+++ b/tests/spec/test_taskspec.py
@@ -559,3 +559,16 @@ def fn():
         lazy_import=True)
 
     assert spec.to_task(dag=DAG())
+
+
+def test_constructor_deep_copies_spec_and_meta(tmp_directory, tmp_imports):
+    meta = Meta.default_meta({'extract_product': False})
+    spec = {
+        'source': 'sample.sql',
+        'product': 'some_file.txt',
+    }
+    task_spec = TaskSpec(data=spec, meta=meta, project_root='.')
+
+    # test they are different objects
+    assert spec is not task_spec.data
+    assert meta is not task_spec.meta


### PR DESCRIPTION
create deepcopies of the `data` and `meta` parameters to the
TaskSpec `__init__` function so as not to cause side-effects
outside the class

Issue: https://github.com/ploomber/ploomber/issues/358

Testing Done: 

(ploomber) bibhash@pop-os:~/Work/ploomber$ pytest tests/spec/test_taskspec.py 
=================================================================================================== test session starts ===================================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/bibhash/Work/ploomber, configfile: pyproject.toml
plugins: cov-3.0.0, anyio-3.3.4
collected 48 items                                                                                                                                                                                                        

tests/spec/test_taskspec.py ................................................                                                                                                                                        [100%]

==================================================================================================== warnings summary =====================================================================================================
../../miniconda3/envs/ploomber/lib/python3.9/site-packages/ansiwrap/core.py:6
  /home/bibhash/miniconda3/envs/ploomber/lib/python3.9/site-packages/ansiwrap/core.py:6: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

tests/spec/test_taskspec.py::test_initialization[spec0-NotebookRunner]
tests/spec/test_taskspec.py::test_add_hook
tests/spec/test_taskspec.py::test_add_hook
  /home/bibhash/miniconda3/envs/ploomber/lib/python3.9/site-packages/jsonschema/validators.py:190: DeprecationWarning: Passing a schema to Validator.iter_errors is deprecated and will be removed in a future release. Call validator.evolve(schema=new_schema).iter_errors(...) instead.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================================================= 48 passed, 4 warnings in 0.42s ==============================================================================================