### PR TITLE
Fix: issue #330, add venv dir to .gitignore

### DIFF
--- a/src/ploomber/cli/install.py
+++ b/src/ploomber/cli/install.py
@@ -77,12 +77,18 @@ def main_pip(use_lock):
     cmdr = Commander()
 
     # TODO: modify readme to add how to activate env? probably also in conda
-    # TODO: add to gitignore, create if it doesn't exist
     name = Path('.').resolve().name
 
     venv_dir = f'venv-{name}'
     cmdr.run('python', '-m', 'venv', venv_dir, description='Creating venv')
-    cmdr.append_inline(venv_dir, '.gitignore')
+
+    # add venv_dir to .gitignore if it doesn't exist
+    if Path('.gitignore').exists():
+        with open('.gitignore') as f:
+            if venv_dir not in f.read():
+                cmdr.append_inline(venv_dir, '.gitignore')
+    else:
+        cmdr.append_inline(venv_dir, '.gitignore')
 
     folder, bin_name = _get_pip_folder_and_bin_name()
     pip = str(Path(venv_dir, folder, bin_name))

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -336,10 +336,17 @@ def test_install_pip(tmp_directory):
     else:
         expected_command = f'source {name}/bin/activate'
 
+    counter = 0
+    with open('.gitignore') as f:
+        for line in f:
+            if name in line:
+                counter += 1
+
     assert Path('.gitignore').read_text() == f'\n{name}\n'
     assert expected_command in result.stdout
     assert Path('requirements.lock.txt').exists()
     assert result.exit_code == 0
+    assert counter == 1
 
 
 def test_non_package_with_pip(tmp_directory):


### PR DESCRIPTION
Add venv directory to .gitignore if it doesn't exist and corresponding unitest was added.
Fix issue #330