### PR TITLE
Catch error when p does not have attribute Task

### DIFF
--- a/src/ploomber/products/metaproduct.py
+++ b/src/ploomber/products/metaproduct.py
@@ -112,7 +112,11 @@ class MetaProduct(Mapping):
     @task.setter
     def task(self, value):
         for p in self.products:
-            p.task = value
+            if hasattr(p, 'task'):
+                p.task = value
+                continue
+            else:
+                raise TypeError(f"It doesn't look like a Product instance, got object of type {type(p)}")
 
     def exists(self):
         return all([p.exists() for p in self.products])

--- a/tests/products/test_metaproduct.py
+++ b/tests/products/test_metaproduct.py
@@ -94,6 +94,17 @@ def test_upload():
 
     p1.upload.assert_called_once_with()
     p2.upload.assert_called_once_with()
+    
+def test_metaproduct():
+    
+    test_dictionary_fails = {'a': 'something'}
+    test_dictionary_passes = {'a': File('something')}
+    
+    PythonCallable(_do_stuff, test_dictionary_fails, dag=DAG())
+    PythonCallable(_do_stuff, test_dictionary_passes, dag=DAG())
+    
+    ## Need to add something here <> 
+
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Contributes to 

https://github.com/ploomber/ploomber/issues/357 

Summary: modified metaproduct.py

```
def task(self, value):
    for p in self.products:
        if hasattr(p, 'task'):
            p.task = value
            continue
        else:
            raise TypeError(f"It doesn't look like a Product instance, got object of type {type(p)}")

```

currently working on adding test to https://github.com/ploomber/ploomber/blob/master/tests/products/test_metaproduct.py