### PR TITLE
disaable stats from CI

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -71,6 +71,8 @@ jobs:
         pip install --editable tests/assets/test_pkg
 
     - name: Run tests
+      env:
+        PLOOMBER_STATS_ENABLED: false
       run: |
         eval "$(conda shell.bash hook)"
         conda activate conda-env

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -76,6 +76,8 @@ jobs:
         pip install --editable tests/assets/test_pkg
 
     - name: Run tests
+      env:
+        PLOOMBER_STATS_ENABLED: false
       shell: bash -l {0}
       run: |
         eval "$(conda shell.bash hook)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
     - name: Run tests
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PLOOMBER_STATS_ENABLED: false
       run: |
         eval "$(conda shell.bash hook)"
         conda activate conda-env


### PR DESCRIPTION
I disabled the stats in the CI. Needed to change some of the telemetry_tests (just minor changes). Please review for your awareness.

I also saw you're working on the stats improvements, once this PR is merged, you may want to rebase to get the new `test_telemetry.py`