### PR TITLE
Add instructions on how to configure `JupyterLab` to open `.py` files as notebooks with a single click

### DIFF
--- a/doc/user-guide/jupyter.rst
+++ b/doc/user-guide/jupyter.rst
@@ -449,7 +449,13 @@ the following settings in the ``Document Manager`` section:"
 
     {
       "defaultViewers": {
+        "markdown": "Jupytext Notebook",
+        "myst": "Jupytext Notebook",
+        "r-markdown": "Jupytext Notebook",
+        "quarto": "Jupytext Notebook",
+        "julia": "Jupytext Notebook",
         "python": "Jupytext Notebook",
+        "r": "Jupytext Notebook"
       }
     }
 

--- a/doc/user-guide/jupyter.rst
+++ b/doc/user-guide/jupyter.rst
@@ -435,7 +435,7 @@ build next and understand dependencies among tasks.
 If you want to take a quick look at your pipeline, you may use
 ``ploomber interact`` from a terminal to get the ``dag`` object.
 
-Opening `.py` files as notebooks with a single click
+Opening files as notebooks with a single click
 ----------------------------------------------------
 
 It is now possible to open ``.py`` files as notebooks in ``JuptyerLab`` with a single
@@ -453,4 +453,4 @@ the following settings in the ``Document Manager`` section:"
       }
     }
 
-For more information see the official docs here `here <https://github.com/mwouts/jupytext#:~:text=With%20a%20click%20on%20the%20text%20file%20in%20JupyterLab,)>`_
+For more information see the official docs here `here <https://github.com/mwouts/jupytext#install>`_

--- a/doc/user-guide/jupyter.rst
+++ b/doc/user-guide/jupyter.rst
@@ -463,4 +463,4 @@ the following settings in the ``Document Manager`` section:"
       }
     }
 
-For more information see the official docs here `here <https://github.com/mwouts/jupytext#install>`_
+For more information see the official docs `here <https://github.com/mwouts/jupytext#install>`_

--- a/doc/user-guide/jupyter.rst
+++ b/doc/user-guide/jupyter.rst
@@ -65,6 +65,10 @@ you to develop pipelines interactively.
    :target: https://ploomber.io/images/doc/lab-open-with-notebook.png
    :alt: lab-open-with-notebook
 
+.. note::
+
+   If you want to configure jupyterlab to open .py files as notebooks with a single click, see the :ref:`Opening files as notebooks with a single click <opening-files-as-notebooks-with-a-single-click>` section
+
 
 .. important::
 

--- a/doc/user-guide/jupyter.rst
+++ b/doc/user-guide/jupyter.rst
@@ -434,3 +434,23 @@ build next and understand dependencies among tasks.
 
 If you want to take a quick look at your pipeline, you may use
 ``ploomber interact`` from a terminal to get the ``dag`` object.
+
+Opening `.py` files as notebooks with a single click
+----------------------------------------------------
+
+It is now possible to open `.py` files as notebooks in `JuptyerLab` with a single
+click (with  `jupytext>=1.13.2`).
+
+In order to do this "change the default viewer for text notebooks by copy-pasting
+the following settings in the `Document Manager` section:"
+
+.. code-block:: JSON
+    :class: text-editor
+
+    {
+      "defaultViewers": {
+        "python": "Jupytext Notebook",
+      }
+    }
+
+For more information see the official docs here `here <https://github.com/mwouts/jupytext#:~:text=With%20a%20click%20on%20the%20text%20file%20in%20JupyterLab,)>`_

--- a/doc/user-guide/jupyter.rst
+++ b/doc/user-guide/jupyter.rst
@@ -438,11 +438,11 @@ If you want to take a quick look at your pipeline, you may use
 Opening `.py` files as notebooks with a single click
 ----------------------------------------------------
 
-It is now possible to open `.py` files as notebooks in `JuptyerLab` with a single
-click (with  `jupytext>=1.13.2`).
+It is now possible to open ``.py`` files as notebooks in ``JuptyerLab`` with a single
+click (with  ``jupytext>=1.13.2``).
 
 In order to do this "change the default viewer for text notebooks by copy-pasting
-the following settings in the `Document Manager` section:"
+the following settings in the ``Document Manager`` section:"
 
 .. code-block:: JSON
     :class: text-editor


### PR DESCRIPTION
Closes #427 