### PR TITLE
Improved error message when pipeline.yaml does not exist

### DIFF
--- a/src/ploomber/entrypoint.py
+++ b/src/ploomber/entrypoint.py
@@ -63,7 +63,7 @@ def find_entry_point_type(entry_point):
         return type_
     else:
         if Path(entry_point).suffix == '.yaml':
-            raise Exception('Could not determine the entry point type from value: ' 
+            raise ValueError('Could not determine the entry point type from value: ' 
             f'{entry_point!r}. The file does not exist.')
         else:
             raise ValueError(

--- a/src/ploomber/entrypoint.py
+++ b/src/ploomber/entrypoint.py
@@ -62,13 +62,16 @@ def find_entry_point_type(entry_point):
     if type_:
         return type_
     else:
-        raise ValueError(
-            'Could not determine the entry point type from value: '
-            f'{entry_point!r}. Expected '
-            'an existing file with extension .yaml or .yml, '
-            'existing directory, glob-like pattern '
-            '(i.e., *.py) or dotted path '
-            '(i.e., module.sub_module.factory_function). Verify your input.')
+        if Path('my_file.yaml').suffix == '.yaml':
+            raise Exception("Path does'nt exist")
+        else:
+            raise ValueError(
+                'Could not determine the entry point type from value: '
+                f'{entry_point!r}. Expected '
+                'an existing file with extension .yaml or .yml, '
+                'existing directory, glob-like pattern '
+                '(i.e., *.py) or dotted path '
+                '(i.e., module.sub_module.factory_function). Verify your input.')
 
 
 def try_to_find_entry_point_type(entry_point):

--- a/src/ploomber/entrypoint.py
+++ b/src/ploomber/entrypoint.py
@@ -62,8 +62,9 @@ def find_entry_point_type(entry_point):
     if type_:
         return type_
     else:
-        if Path('my_file.yaml').suffix == '.yaml':
-            raise Exception("Path does'nt exist")
+        if Path(entry_point).suffix == '.yaml':
+            raise Exception('Could not determine the entry point type from value: ' 
+            f'{entry_point!r}. The file does not exist.')
         else:
             raise ValueError(
                 'Could not determine the entry point type from value: '

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -34,5 +34,8 @@ def test_dotted_path_that_ends_with_yaml():
 def test_try_to_find_entry_point_type_with_none():
     assert try_to_find_entry_point_type(None) is None
 
-def test_find_entry_point_type_with_none():
-    assert find_entry_point_type(None) is None
+def test_find_entry_point_type_with_yaml():
+    with pytest.raises(ValueError) as excinfo:
+        EntryPoint('some.yaml')
+
+    assert 'Could not determine the entry point type' in str(excinfo.value)

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ploomber.entrypoint import EntryPoint, try_to_find_entry_point_type
+from ploomber.entrypoint import EntryPoint, try_to_find_entry_point_type, find_entry_point_type
 
 
 @pytest.mark.parametrize('value, type_', [
@@ -33,3 +33,6 @@ def test_dotted_path_that_ends_with_yaml():
 
 def test_try_to_find_entry_point_type_with_none():
     assert try_to_find_entry_point_type(None) is None
+
+def test_find_entry_point_type_with_none():
+    assert find_entry_point_type(None) is None


### PR DESCRIPTION
Improved error message when pipeline.yaml does not exist using `pathlib.Path`.

Resolves #509 