### PR TITLE
adding typo handling and updating tests for: cli should suggest the a…

### DIFF
--- a/src/ploomber/cli/cli.py
+++ b/src/ploomber/cli/cli.py
@@ -181,7 +181,30 @@ def cmd_router():
     }
 
     # users may attempt to run execute/run, suggest to use build instead
-    alias = {'execute': 'build', 'run': 'build'}
+    # users may make typos when running one of the commands, suggest correct spelling on obvious typos
+    alias = {
+        'execute': 'build',
+        'run': 'build',
+        'bulid': 'build',
+        'buld': 'build',
+        'bild': 'build',
+        'uild': 'build',
+        'buil': 'build',
+        'example': 'examples',
+        'exemples': 'examples',
+        'exmples': 'examples',
+        'exampes': 'examples',
+        'tsk': 'task',
+        'tas': 'task',
+        'rport': 'report',
+        'reprt': 'report',
+        'repor': 'report',
+        'stat': 'status',
+        'stats': 'status',
+        'satus': 'status',
+        'inteact': 'interact',
+        'interat': 'interact'
+    }
 
     if cmd_name in custom:
         # NOTE: we don't use the argument here, it is parsed by _main

--- a/tests/cli/test_custom.py
+++ b/tests/cli/test_custom.py
@@ -33,9 +33,28 @@ def test_no_options(monkeypatch):
 @pytest.mark.parametrize('cmd, suggestion', [
     ['execute', 'build'],
     ['run', 'build'],
+    ['bulid', 'build'],
+    ['buld', 'build'],
+    ['bild', 'build'],
+    ['uild', 'build'],
+    ['buil', 'build'],
+    ['example', 'examples'],
+    ['exemples', 'examples'],
+    ['exmples', 'examples'],
+    ['exampes', 'examples'],
+    ['tsk', 'task'],
+    ['tas', 'task'],
+    ['rport', 'report'],
+    ['reprt', 'report'],
+    ['repor', 'report'],
+    ['stat', 'status'],
+    ['stats', 'status'],
+    ['satus', 'status'],
+    ['inteact', 'interact'],
+    ['interat', 'interact'],
 ])
 def test_suggestions(monkeypatch, capsys, cmd, suggestion):
-    monkeypatch.setattr(sys, 'argv', ['ploomber', 'execute'])
+    monkeypatch.setattr(sys, 'argv', ['ploomber', cmd])
 
     with pytest.raises(SystemExit) as excinfo:
         cmd_router()


### PR DESCRIPTION
hello

flake8 give me ./src/ploomber/cli/cli.py:184:80: E501 line too long (102 > 79 characters)

any suggestions how to do this differently, thanks 

