### PR TITLE
fix: warn large resource issue#429

### DIFF
--- a/src/ploomber/products/_resources.py
+++ b/src/ploomber/products/_resources.py
@@ -2,6 +2,8 @@ from copy import deepcopy
 import hashlib
 from pathlib import Path
 from collections.abc import Mapping
+import os
+import warnings
 
 _KEY = 'resources_'
 
@@ -20,6 +22,16 @@ def _check_is_file(path, key):
         raise FileNotFoundError(
             f'Error reading params.resources_ with key {key!r}. '
             f'Expected value {str(path)!r} to be an existing file.')
+
+
+def _check_file_size(path):
+    __resource_file_stat = os.stat(path)
+    __resource_file_size = __resource_file_stat.st_size / 1E+6
+    if __resource_file_size > 1:
+        warnings.warn(
+            "File too large. "
+            "Resource {path}[{__resource_file_size:.2f}MB] > 1MB".format(
+                path=path, __resource_file_size=__resource_file_size))
 
 
 def _validate(params):
@@ -79,6 +91,7 @@ def process_resources(params):
     for key, value in params[_KEY].items():
         path = _cast_to_path(value, key)
         _check_is_file(path, key)
+        _check_file_size(path)
         digest = hashlib.md5(path.read_bytes()).hexdigest()
         resources[key] = digest
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,27 @@
+import warnings
+from ploomber.products import _resources
+
+
+def test_process_resources_warns_on_large_file(monkeypatch):
+    import stat
+
+    # this will cause the os.stat call in the _resources module to return 2E+6
+    mock_fsize = 2E+6
+    mock_fname = "test_resource_file.conf"
+    monkeypatch.setattr(_resources.os, 'stat', lambda _: stat)
+    mock_fstat_details = _resources.os.stat(__file__)
+    mock_fstat_details.st_size = mock_fsize
+    monkeypatch.setattr(_resources.os, 'stat', lambda _: mock_fstat_details)
+
+    expected_warn_msg = "File too large. Resource {0}[{1:.2f}MB] > 1MB".format(
+        mock_fname, mock_fsize / 1E+6)
+
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        _resources._check_file_size(mock_fname)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert str(w[-1].message) == expected_warn_msg, \
+            "Warning is not matching.\nActual warning: " + \
+            str(w[-1].message) + "\nExpected warning: " + expected_warn_msg


### PR DESCRIPTION
PR for Issue #429

changes in the PR:

- implementation of `_check_file_size(path)` warns user about file > 1MB
- function call before calculating hashing of resource file
-----
**pipeline.yaml**
```yaml
tasks:
  - source: tasks.raw.get
    product: products/raw/get.csv
    params:
      resources_:
        file: conf.yaml
    .....
```
**conf.yaml**: dummy file with ~9MB of data
**script used to test**:
```python
def get(resources_, product):
    print(" -------------- Debug --------------")
    print(open(resources_['file']).read()[:10])
    ....
```
**output**:
`File too large. Resource <DIR-PATH>/conf.yaml[9.98MB] > 1MB`
