### PR TITLE
Improvements to the {{git}} placeholder feature

### DIFF
--- a/doc/api/spec.rst
+++ b/doc/api/spec.rst
@@ -1043,6 +1043,9 @@ even if not defined in the ``env.yaml`` (or if you don't have a ``env.yaml`` alt
 * ``{{root}}``: Absolute path to project's root folder. It is usually the same as ``{{here}}``, except when the project is a package (i.e., it has ``setup.py`` file), in such a case, it points to the parent directory of the ``setup.py`` file.
 * ``{{user}}``: Current username
 * ``{{now}}``: Current timestamp in ISO 8601 format (*Added in Ploomber 0.13.4*)
+* ``{{git_hash}}``: git tag (if any) or git hash (*Added in Ploomber 0.17.1*)
+* ``{{git}}``: returns the branch name (if at the tip of it), git tag (if any), or git hash (*Added in Ploomber 0.17.1*)
+
 
 A common use case for this is when passing paths to files to scripts/notebooks. For example, let's say your script has to read a file from a specific location. Using ``{{here}}`` turns path into absolute so you can ready it when using Jupyter, even if the script is in a different location than your ``pipeline.yaml``.
 

--- a/src/ploomber/env/envdict.py
+++ b/src/ploomber/env/envdict.py
@@ -5,12 +5,15 @@ from collections.abc import Mapping
 from reprlib import Repr
 
 import yaml
+from jinja2 import Template, StrictUndefined
 
 from ploomber.env import validate
 from ploomber.env.expand import EnvironmentExpander
 from ploomber.env.frozenjson import FrozenJSON
 from ploomber import repo
 from ploomber.util import default
+from ploomber.placeholders import util
+from ploomber.exceptions import BaseException
 
 
 # TODO: custom expanders, this could be done trough another special directive
@@ -141,6 +144,7 @@ class EnvDict(Mapping):
 
         if path_to_here is not None and repo.is_repo(path_to_here):
             placeholders['git'] = '{{git}}'
+            placeholders['git_hash'] = '{{git_hash}}'
 
         return placeholders
 
@@ -257,6 +261,45 @@ class EnvDict(Mapping):
         obj = copy(self)
         obj._inplace_replace_flatten_keys(to_replace)
         return obj
+
+    def _render(self, raw_value):
+        placeholders = util.get_tags_in_str(raw_value)
+
+        if not placeholders:
+            return raw_value, placeholders
+
+        undefined = placeholders - set(self)
+
+        if undefined:
+            msg = _error_message_for_undefined_list(undefined)
+            raise BaseException(
+                f'Error replacing placeholders:\n{msg}\n\nLoaded env: '
+                f'{self!r}')
+
+        value = Template(raw_value, undefined=StrictUndefined).render(**self)
+
+        return value, placeholders
+
+
+def _error_message_for_undefined_list(undefined):
+    return '\n'.join(_error_message_for_undefined(u) for u in undefined)
+
+
+def _error_message_for_undefined(u):
+    git_ = 'Ensure git is installed and git repository exists'
+    reasons = {
+        'git':
+        git_,
+        'git_hash':
+        git_,
+        'here':
+        'Ensure the spec was initialized from a file',
+        'root': ('Ensure a pipeline.yaml or setup.py exist in the '
+                 'current directory or a parent directory')
+    }
+    howto = reasons.get(u, 'Ensure the placeholder is defined in the env')
+
+    return '  * {{' + u + '}}: ' + howto
 
 
 def load_from_source(source):

--- a/src/ploomber/env/envdict.py
+++ b/src/ploomber/env/envdict.py
@@ -9,6 +9,7 @@ import yaml
 from ploomber.env import validate
 from ploomber.env.expand import EnvironmentExpander
 from ploomber.env.frozenjson import FrozenJSON
+from ploomber import repo
 from ploomber.util import default
 
 
@@ -71,7 +72,7 @@ class EnvDict(Mapping):
 
             # add default placeholders but override them if they are defined
             # in the raw data
-            default = self._default_dict(include_here=path_to_here is not None)
+            default = self._default_dict(path_to_here=path_to_here)
             self._default_keys = set(default) - set(raw_data)
             raw_data = {**default, **raw_data}
 
@@ -124,7 +125,8 @@ class EnvDict(Mapping):
         return self._default_keys
 
     @staticmethod
-    def _default_dict(include_here):
+    def _default_dict(path_to_here):
+
         placeholders = {
             'user': '{{user}}',
             'cwd': '{{cwd}}',
@@ -134,8 +136,11 @@ class EnvDict(Mapping):
         if default.try_to_find_root_recursively() is not None:
             placeholders['root'] = '{{root}}'
 
-        if include_here:
+        if path_to_here is not None:
             placeholders['here'] = '{{here}}'
+
+        if path_to_here is not None and repo.is_repo(path_to_here):
+            placeholders['git'] = '{{git}}'
 
         return placeholders
 
@@ -262,7 +267,7 @@ def load_from_source(source):
     Returns
     -------
     dict
-        Raw dictioanry
+        Raw dictionary
     pathlib.Path
         Path to the loaded file, None if source is a dict
     str

--- a/src/ploomber/repo.py
+++ b/src/ploomber/repo.py
@@ -33,7 +33,7 @@ def is_repo(path):
     if not shutil.which('git'):
         return False
 
-    out = subprocess.run(['git', '-C', path, 'rev-parse'],
+    out = subprocess.run(['git', '-C', str(path), 'rev-parse'],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
     repo_exists = out.returncode == 0

--- a/src/ploomber/repo.py
+++ b/src/ploomber/repo.py
@@ -6,6 +6,7 @@ import subprocess
 import shlex
 import sys
 from pathlib import Path
+import shutil
 
 
 def _run_command(path, command):
@@ -22,6 +23,17 @@ def _run_command(path, command):
         s = s[:-1]
 
     return s
+
+
+def is_repo(path):
+    if path is None:
+        return False
+
+    if not shutil.which('git'):
+        return False
+
+    out = subprocess.run(['git', '-C', path, 'rev-parse'], capture_output=True)
+    return out.returncode == 0
 
 
 def get_git_summary(path):

--- a/src/ploomber/repo.py
+++ b/src/ploomber/repo.py
@@ -32,7 +32,9 @@ def is_repo(path):
     if not shutil.which('git'):
         return False
 
-    out = subprocess.run(['git', '-C', path, 'rev-parse'], capture_output=True)
+    out = subprocess.run(['git', '-C', path, 'rev-parse'],
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE)
     return out.returncode == 0
 
 

--- a/src/ploomber/repo.py
+++ b/src/ploomber/repo.py
@@ -40,8 +40,9 @@ def is_repo(path):
 
     if repo_exists:
         try:
-            # edge case: if the repo doesn't have any commits, the following will
-            # fail. we require a repo with at least one commit for git to work
+            # edge case: if the repo doesn't have any commits, the following
+            # will fail. we require a repo with at least one commit for git
+            # to work
             git_hash(path)
         except subprocess.CalledProcessError:
             return False

--- a/src/ploomber/repo.py
+++ b/src/ploomber/repo.py
@@ -36,7 +36,17 @@ def is_repo(path):
     out = subprocess.run(['git', '-C', path, 'rev-parse'],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
-    return out.returncode == 0
+    repo_exists = out.returncode == 0
+
+    if repo_exists:
+        try:
+            # edge case: if the repo doesn't have any commits, the following will
+            # fail. we require a repo with at least one commit for git to work
+            git_hash(path)
+        except subprocess.CalledProcessError:
+            return False
+        else:
+            return True
 
 
 def get_git_summary(path):

--- a/src/ploomber/repo.py
+++ b/src/ploomber/repo.py
@@ -26,6 +26,7 @@ def _run_command(path, command):
 
 
 def is_repo(path):
+    """Check if the path is in a git repo"""
     if path is None:
         return False
 
@@ -39,13 +40,32 @@ def is_repo(path):
 
 
 def get_git_summary(path):
-    """Get one line git summary"""
+    """Get one line git summary: {hash} {commit-message}
+    """
     return _run_command(path, 'git show --oneline -s')
 
 
 def git_hash(path):
-    """Get git hash"""
+    """Get git hash
+
+    If tag: {tag-name}
+    If clean commit: {hash}
+    If dirty: {hash}-dirty
+
+    dirty: "A working tree is said to be "dirty" if it contains modifications
+    which have not been committed to the current branch."
+    https://mirrors.edge.kernel.org/pub/software/scm/git/docs/gitglossary.html#def_dirty
+    """
     return _run_command(path, 'git describe --tags --always --dirty=-dirty')
+
+
+def git_location(path):
+    """
+    Returns branch name if at the latest commit, otherwise the hash
+    """
+    hash_ = git_hash(path)
+    git_branch = current_branch(path)
+    return git_branch or hash_
 
 
 def get_git_timestamp(path):
@@ -86,16 +106,12 @@ def get_diff(path):
 
 
 def get_git_info(path):
-    hash_ = git_hash(path)
-    git_branch = current_branch(path)
-    git_location = git_branch or hash_
-
     return dict(git_summary=get_git_summary(path),
-                git_hash=hash_,
+                git_hash=git_hash(path),
                 git_diff=get_diff(path),
                 git_timestamp=get_git_timestamp(path),
-                git_branch=git_branch,
-                git_location=git_location)
+                git_branch=current_branch(path),
+                git_location=git_location(path))
 
 
 def save_env_metadata(env, path_to_output):

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -289,11 +289,14 @@ class DAGSpec(MutableMapping):
         path_to_defaults = default.path_to_env_from_spec(
             path_to_spec=self._path)
 
+        # there is an env.yaml we can use
         if path_to_defaults:
             defaults = yaml.safe_load(Path(path_to_defaults).read_text())
             self.env = EnvDict(env,
                                path_to_here=self._parent_path,
                                defaults=defaults)
+
+        # there is no env.yaml
         else:
             self.env = EnvDict(env, path_to_here=self._parent_path)
 

--- a/tests/cli/test_custom.py
+++ b/tests/cli/test_custom.py
@@ -77,7 +77,7 @@ def test_build_suggestion(monkeypatch, capsys):
     'task',
     'interact',
 ])
-def test_help(cmd, monkeypatch_session, tmp_directory):
+def test_help(cmd, monkeypatch, tmp_directory):
     Path('pipeline.yaml').touch()
 
     elements = ['ploomber']
@@ -85,7 +85,7 @@ def test_help(cmd, monkeypatch_session, tmp_directory):
     if cmd:
         elements.append(cmd)
 
-    monkeypatch_session.setattr(sys, 'argv', elements + ['--help'])
+    monkeypatch.setattr(sys, 'argv', elements + ['--help'])
 
     with pytest.raises(SystemExit) as excinfo:
         cmd_router()
@@ -95,8 +95,8 @@ def test_help(cmd, monkeypatch_session, tmp_directory):
 
 @pytest.mark.parametrize(
     'cmd', ['build', 'plot', 'report', 'status', 'task', 'interact'])
-def test_help_shows_env_keys(cmd, monkeypatch_session, tmp_nbs, capsys):
-    monkeypatch_session.setattr(sys, 'argv', ['ploomber', cmd, '--help'])
+def test_help_shows_env_keys(cmd, monkeypatch, tmp_nbs, capsys):
+    monkeypatch.setattr(sys, 'argv', ['ploomber', cmd, '--help'])
 
     with pytest.raises(SystemExit) as excinfo:
         cmd_router()
@@ -110,9 +110,9 @@ def test_help_shows_env_keys(cmd, monkeypatch_session, tmp_nbs, capsys):
     'cmd', ['build', 'plot', 'report', 'status', 'task', 'interact'])
 def test_help_shows_env_keys_w_entry_point(cmd, tmp_nbs,
                                            add_current_to_sys_path,
-                                           monkeypatch_session, capsys):
-    monkeypatch_session.setattr(
-        sys, 'argv', ['ploomber', cmd, '-e', 'factory.make', '--help'])
+                                           monkeypatch, capsys):
+    monkeypatch.setattr(sys, 'argv',
+                        ['ploomber', cmd, '-e', 'factory.make', '--help'])
 
     with pytest.raises(SystemExit) as excinfo:
         cmd_router()
@@ -122,14 +122,14 @@ def test_help_shows_env_keys_w_entry_point(cmd, tmp_nbs,
     assert not excinfo.value.code
 
 
-def test_build(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(
-        sys, 'argv', ['python', '--entry-point', 'test_pkg.entry.with_doc'])
+def test_build(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(sys, 'argv',
+                        ['python', '--entry-point', 'test_pkg.entry.with_doc'])
     build.main(catch_exception=False)
 
 
-def test_build_help_shows_docstring(capsys, monkeypatch_session):
-    monkeypatch_session.setattr(
+def test_build_help_shows_docstring(capsys, monkeypatch):
+    monkeypatch.setattr(
         sys, 'argv',
         ['python', '--entry-point', 'test_pkg.entry.with_doc', '--help'])
 
@@ -143,15 +143,15 @@ def test_build_help_shows_docstring(capsys, monkeypatch_session):
 
 
 @pytest.mark.parametrize('arg', ['.', '*.py'])
-def test_build_from_directory(arg, monkeypatch_session, tmp_nbs_no_yaml):
+def test_build_from_directory(arg, monkeypatch, tmp_nbs_no_yaml):
     Path('output').mkdir()
-    monkeypatch_session.setattr(sys, 'argv', ['python', '--entry-point', arg])
+    monkeypatch.setattr(sys, 'argv', ['python', '--entry-point', arg])
     build.main(catch_exception=False)
 
 
-def test_status(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(
-        sys, 'argv', ['python', '--entry-point', 'test_pkg.entry.with_doc'])
+def test_status(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(sys, 'argv',
+                        ['python', '--entry-point', 'test_pkg.entry.with_doc'])
     status.main(catch_exception=False)
 
 
@@ -164,53 +164,53 @@ def test_status(monkeypatch_session, tmp_sample_dir):
     [['--include-products'], 'pipeline.entry.png', True],
     [['-i'], 'pipeline.entry.png', True],
 ])
-def test_plot(custom_args, monkeypatch_session, tmp_sample_dir, output,
+def test_plot(custom_args, monkeypatch, tmp_sample_dir, output,
               include_products):
     args_defaults = ['python', '--entry-point', 'test_pkg.entry.with_doc']
-    monkeypatch_session.setattr(sys, 'argv', args_defaults + custom_args)
+    monkeypatch.setattr(sys, 'argv', args_defaults + custom_args)
     mock = Mock()
-    monkeypatch_session.setattr(dag_module.DAG, 'plot', mock)
+    monkeypatch.setattr(dag_module.DAG, 'plot', mock)
     plot.main(catch_exception=False)
 
     mock.assert_called_once_with(output=output,
                                  include_products=include_products)
 
 
-def test_plot_uses_name_if_any(tmp_nbs, monkeypatch_session):
+def test_plot_uses_name_if_any(tmp_nbs, monkeypatch):
     os.rename('pipeline.yaml', 'pipeline.train.yaml')
 
     args_defaults = ['ploomber', '--entry-point', 'pipeline.train.yaml']
-    monkeypatch_session.setattr(sys, 'argv', args_defaults)
+    monkeypatch.setattr(sys, 'argv', args_defaults)
     mock = Mock()
-    monkeypatch_session.setattr(dag_module.DAG, 'plot', mock)
+    monkeypatch.setattr(dag_module.DAG, 'plot', mock)
     plot.main(catch_exception=False)
 
     mock.assert_called_once_with(output='pipeline.train.png',
                                  include_products=False)
 
 
-def test_report_includes_plot(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(
-        sys, 'argv', ['python', '--entry-point', 'test_pkg.entry.with_doc'])
+def test_report_includes_plot(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(sys, 'argv',
+                        ['python', '--entry-point', 'test_pkg.entry.with_doc'])
 
     mock_plot = Mock()
-    monkeypatch_session.setattr(dag_module.DAG, 'plot', mock_plot)
+    monkeypatch.setattr(dag_module.DAG, 'plot', mock_plot)
     report.main(catch_exception=False)
 
     mock_plot.assert_called_once()
 
 
-def test_log_enabled(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(sys, 'argv', [
+def test_log_enabled(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(sys, 'argv', [
         'python', '--entry-point', 'test_pkg.entry.with_doc', '--log', 'INFO'
     ])
     build.main(catch_exception=False)
 
 
 @pytest.mark.skip(reason="Skipping test so it won't call log_api")
-def test_interactive_session(tmp_sample_dir, monkeypatch_session):
+def test_interactive_session(tmp_sample_dir, monkeypatch):
     mock_log = Mock()
-    monkeypatch_session.setattr(telemetry, 'log_api', mock_log)
+    monkeypatch.setattr(telemetry, 'log_api', mock_log)
     res = subprocess.run(
         ['ploomber', 'interact', '--entry-point', 'test_pkg.entry.with_doc'],
         input=b'type(dag)',
@@ -262,58 +262,58 @@ def test_interactive_session_develop(monkeypatch, tmp_nbs):
     assert Path('plot.py').read_text().strip() == '2 + 2'
 
 
-def test_interactive_session_render_fails(monkeypatch_session, tmp_nbs):
-    monkeypatch_session.setattr(sys, 'argv', ['python'])
+def test_interactive_session_render_fails(monkeypatch, tmp_nbs):
+    monkeypatch.setattr(sys, 'argv', ['python'])
 
     mock = Mock(side_effect=['quit'])
 
     def fail(self):
         raise Exception
 
-    with monkeypatch_session.context() as m:
+    with monkeypatch.context() as m:
         m.setattr('builtins.input', mock)
         m.setattr(DAG, 'render', fail)
         interact.main(catch_exception=False)
 
 
-def test_replace_env_value(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(sys, 'argv', [
+def test_replace_env_value(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(sys, 'argv', [
         'python', '--entry-point', 'test_pkg.entry.with_doc',
         '--env--path--data', '/another/path'
     ])
     build.main(catch_exception=False)
 
 
-def test_w_param(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(sys, 'argv', [
+def test_w_param(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(sys, 'argv', [
         'python', '--entry-point', 'test_pkg.entry.with_param',
         'some_value_for_param'
     ])
     build.main(catch_exception=False)
 
 
-def test_no_doc(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(
-        sys, 'argv', ['python', '--entry-point', 'test_pkg.entry.no_doc'])
+def test_no_doc(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(sys, 'argv',
+                        ['python', '--entry-point', 'test_pkg.entry.no_doc'])
     build.main(catch_exception=False)
 
 
-def test_incomplete_doc(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(
+def test_incomplete_doc(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(
         sys, 'argv',
         ['python', '--entry-point', 'test_pkg.entry.incomplete_doc'])
     build.main(catch_exception=False)
 
 
-def test_invalid_doc(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(
+def test_invalid_doc(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(
         sys, 'argv', ['python', '--entry-point', 'test_pkg.entry.invalid_doc'])
     build.main(catch_exception=False)
 
 
-def test_invalid_entry_point_value(monkeypatch_session):
-    monkeypatch_session.setattr(
-        sys, 'argv', ['python', '--entry-point', 'invalid_entry_point'])
+def test_invalid_entry_point_value(monkeypatch):
+    monkeypatch.setattr(sys, 'argv',
+                        ['python', '--entry-point', 'invalid_entry_point'])
 
     with pytest.raises(ValueError) as excinfo:
         build.main(catch_exception=False)
@@ -325,8 +325,8 @@ def test_invalid_entry_point_value(monkeypatch_session):
     ['--entry-point', 'pipeline.yaml'],
     ['--entry-point', 'pipeline.yml'],
 ])
-def test_invalid_spec_entry_point(args, monkeypatch_session):
-    monkeypatch_session.setattr(sys, 'argv', ['python'] + args)
+def test_invalid_spec_entry_point(args, monkeypatch):
+    monkeypatch.setattr(sys, 'argv', ['python'] + args)
 
     with pytest.raises(ValueError) as excinfo:
         build.main(catch_exception=False)
@@ -334,16 +334,16 @@ def test_invalid_spec_entry_point(args, monkeypatch_session):
     assert 'Could not determine the entry point type' in str(excinfo.value)
 
 
-def test_nonexisting_module(monkeypatch_session):
-    monkeypatch_session.setattr(
+def test_nonexisting_module(monkeypatch):
+    monkeypatch.setattr(
         sys, 'argv', ['python', '--entry-point', 'some_module.some_function'])
 
     with pytest.raises(ImportError):
         build.main(catch_exception=False)
 
 
-def test_invalid_function(monkeypatch_session):
-    monkeypatch_session.setattr(
+def test_invalid_function(monkeypatch):
+    monkeypatch.setattr(
         sys, 'argv',
         ['python', '--entry-point', 'test_pkg.entry.invalid_function'])
 
@@ -351,16 +351,16 @@ def test_invalid_function(monkeypatch_session):
         build.main(catch_exception=False)
 
 
-def test_undecorated_function(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(
+def test_undecorated_function(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(
         sys, 'argv',
         ['python', '--entry-point', 'test_pkg.entry.plain_function'])
 
     build.main(catch_exception=False)
 
 
-def test_undecorated_function_w_param(monkeypatch_session, tmp_sample_dir):
-    monkeypatch_session.setattr(sys, 'argv', [
+def test_undecorated_function_w_param(monkeypatch, tmp_sample_dir):
+    monkeypatch.setattr(sys, 'argv', [
         'python', '--entry-point', 'test_pkg.entry.plain_function_w_param',
         'some_value_for_param'
     ])
@@ -425,9 +425,9 @@ def test_parse_doc_if_missing_numpydoc(docstring, expected_summary,
 
 
 @pytest.mark.parametrize('args', [[], ['--partially', 'plot']])
-def test_build_command(args, tmp_nbs, monkeypatch_session):
+def test_build_command(args, tmp_nbs, monkeypatch):
     args = ['python', '--entry-point', 'pipeline.yaml'] + args
-    monkeypatch_session.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, 'argv', args)
     build.main(catch_exception=False)
 
 
@@ -456,19 +456,19 @@ def test_build_crash_hides_internal_traceback(tmp_nbs, monkeypatch, capsys):
     ['--status', '--build'],
     ['--on-finish'],
 ])
-def test_task_command(args, tmp_nbs, monkeypatch_session):
+def test_task_command(args, tmp_nbs, monkeypatch):
     args = ['task', '--entry-point', 'pipeline.yaml', 'load'] + args
-    monkeypatch_session.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, 'argv', args)
     task.main(catch_exception=False)
 
 
-def test_task_command_does_not_force_dag_render(tmp_nbs, monkeypatch_session):
+def test_task_command_does_not_force_dag_render(tmp_nbs, monkeypatch):
     """
     Make sure the force flag is only used in task.render and not dag.render
     because we don't want to override the status of other tasks
     """
     args = ['task', 'load', '--force']
-    monkeypatch_session.setattr(sys, 'argv', args)
+    monkeypatch.setattr(sys, 'argv', args)
 
     class CustomParserWrapper(CustomParser):
         def load_from_entry_point_arg(self):
@@ -477,15 +477,15 @@ def test_task_command_does_not_force_dag_render(tmp_nbs, monkeypatch_session):
             type(self).dag_mock = dag_mock
             return dag_mock, args
 
-    monkeypatch_session.setattr(task, 'CustomParser', CustomParserWrapper)
+    monkeypatch.setattr(task, 'CustomParser', CustomParserWrapper)
 
     task.main(catch_exception=False)
 
     CustomParserWrapper.dag_mock.render.assert_called_once_with()
 
 
-def test_build_with_replaced_env_value(tmp_nbs, monkeypatch_session):
-    monkeypatch_session.setattr(
+def test_build_with_replaced_env_value(tmp_nbs, monkeypatch):
+    monkeypatch.setattr(
         sys, 'argv',
         ['python', '--entry-point', 'pipeline.yaml', '--env--sample', 'True'])
     build.main(catch_exception=False)

--- a/tests/cli/test_nb.py
+++ b/tests/cli/test_nb.py
@@ -14,11 +14,11 @@ from ploomber.cli import nb
 
 def git_init():
     subprocess.check_call(['git', 'init'])
+    subprocess.check_call(['git', 'config', 'user.email', 'ci@ploomberio'])
+    subprocess.check_call(['git', 'config', 'user.name', 'Ploomber'])
 
 
 def git_commit():
-    subprocess.check_call(['git', 'config', 'user.email', 'ci@ploomberio'])
-    subprocess.check_call(['git', 'config', 'user.name', 'Ploomber'])
     subprocess.check_call(['git', 'add', '--all'])
     subprocess.check_call(['git', 'commit', '-m', 'commit'])
 
@@ -142,14 +142,16 @@ def test_install_hook(monkeypatch, tmp_nbs):
 
     # commit (should remove injected cells before committing and re-add them
     # after committing)
+    Path('another').touch()
     git_commit()
 
     injected_tag = '# + tags=["injected-parameters"]'
     assert injected_tag in Path('load.py').read_text()
 
-    # check last commit files
+    # check out last committed files
     subprocess.check_call(['git', 'stash'])
 
+    # committed version should not have the injected cell
     assert injected_tag not in Path('load.py').read_text()
 
     assert ('ploomber nb --entry-point pipeline.yaml --remove'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ def tmp_git(tmp_directory):
     git_init()
 
 
+# FIXME: do we need this?
 @pytest.fixture(scope='class')
 def monkeypatch_session():
     from _pytest.monkeypatch import MonkeyPatch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,7 +181,7 @@ def backup_online():
     pass
 
 
-def _delete_dot_git_at(path):
+def _fix_dot_git_permissions(path):
     for root, dirs, files in os.walk(path):
         for dir_ in dirs:
             os.chmod(Path(root, dir_), stat.S_IRWXU)
@@ -189,10 +189,10 @@ def _delete_dot_git_at(path):
             os.chmod(Path(root, file_), stat.S_IRWXU)
 
 
-def _delete_all_dot_git():
+def _fix_all_dot_git_permissions():
     if os.name == 'nt':
-        for path in iglob('**/.git', recursive=True):
-            _delete_dot_git_at(path)
+        for path in iglob(f'{tmp}/.git', recursive=True):
+            _fix_dot_git_permissions(path)
 
 
 @pytest.fixture()
@@ -205,7 +205,7 @@ def tmp_directory():
 
     # some tests create sample git repos, if we are on windows, we need to
     # change permissions to be able to delete the files
-    _delete_all_dot_git()
+    _fix_all_dot_git_permissions(tmp)
 
     os.chdir(old)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 Note: tests organized in folders must contain an init file:
 https://github.com/pytest-dev/pytest/issues/3151#issuecomment-360493948
 """
+import subprocess
 import stat
 import base64
 from copy import copy
@@ -24,6 +25,15 @@ from glob import iglob
 from ploomber.cli import install
 import posthog
 from unittest.mock import Mock, MagicMock
+
+
+def git_init():
+    if Path('CHANGELOG.md').exists():
+        raise ValueError('call git_init in a temporary directory')
+
+    subprocess.run(['git', 'init', '-b', 'mybranch'])
+    subprocess.run(['git', 'add', '--all'])
+    subprocess.run(['git', 'commit', '-m', 'message'])
 
 
 @pytest.fixture(scope='class')
@@ -57,7 +67,6 @@ def fixture_tmp_dir(source):
     # some_fixture = factory('some/path')
     # but didn't work
     def decorator(function):
-
         @wraps(function)
         def wrapper():
             old = os.getcwd()
@@ -85,9 +94,7 @@ def fixture_backup(source):
     """
     Similar to fixture_tmp_dir but backups the content instead
     """
-
     def decorator(function):
-
         @wraps(function)
         def wrapper():
             old = os.getcwd()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,7 @@ def fixture_tmp_dir(source):
 
             # some tests create sample git repos, if we are on windows, we
             # need to change permissions to be able to delete the files
-            _delete_all_dot_git()
+            _fix_all_dot_git_permissions(tmp)
 
             os.chdir(old)
             shutil.rmtree(tmp_dir)
@@ -189,7 +189,7 @@ def _fix_dot_git_permissions(path):
             os.chmod(Path(root, file_), stat.S_IRWXU)
 
 
-def _fix_all_dot_git_permissions():
+def _fix_all_dot_git_permissions(tmp):
     if os.name == 'nt':
         for path in iglob(f'{tmp}/.git', recursive=True):
             _fix_dot_git_permissions(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,13 @@ def git_init():
 
     subprocess.run(['git', 'init', '-b', 'mybranch'])
     subprocess.run(['git', 'add', '--all'])
-    subprocess.run(['git', 'commit', '-m', 'message'])
+    subprocess.run(['git', 'commit', '-m', 'some-commit-message'])
+
+
+@pytest.fixture
+def tmp_git(tmp_directory):
+    Path('file').touch()
+    git_init()
 
 
 @pytest.fixture(scope='class')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,7 +191,7 @@ def _fix_dot_git_permissions(path):
 
 def _fix_all_dot_git_permissions(tmp):
     if os.name == 'nt':
-        for path in iglob(f'{tmp}/.git', recursive=True):
+        for path in iglob(f'{tmp}/**/.git', recursive=True):
             _fix_dot_git_permissions(path)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,9 @@ def git_init():
         raise ValueError('call git_init in a temporary directory')
 
     subprocess.run(['git', 'init', '-b', 'mybranch'])
+    subprocess.check_call(['git', 'config', 'user.email', 'ci@ploomberio'])
+    subprocess.check_call(['git', 'config', 'user.name', 'Ploomber'])
+
     subprocess.run(['git', 'add', '--all'])
     subprocess.run(['git', 'commit', '-m', 'some-commit-message'])
 

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -621,22 +621,22 @@ def test_envdict_git_ignored_if_git_command_fails_and_no_git_placeholder(
 
 
 def test_expand_raw_dict_error_if_missing_key():
-    mapping = {'another_key': 'value'}
+    mapping = EnvDict({'another_key': 'value'})
     d = {'some_stuff': '{{key}}'}
 
-    with pytest.raises(KeyError) as excinfo:
+    with pytest.raises(BaseException) as excinfo:
         expand_raw_dictionary(d, mapping)
 
-    expected = ('"Error replacing placeholder: \'key\' is undefined.'
-                ' Loaded env: {\'another_key\': \'value\'}"')
-    assert expected in str(excinfo.value)
+    assert "Error replacing placeholders:" in str(excinfo.value)
+    assert "* {{key}}: Ensure the placeholder is defined" in str(excinfo.value)
 
 
 def test_expand_raw_dictionary_parses_literals():
-    raw = {'a': '{{a}}', 'b': '{{b}}', 'c': '{{c}}'}
-    mapping = {'a': {1, 2, 3}, 'b': [1, 2, 3], 'c': {'z': 1}}
+    raw = {'a': '{{a}}', 'b': '{{b}}'}
+    mapping = EnvDict({'a': [1, 2, 3], 'b': {'z': 1}})
     out = expand_raw_dictionary(raw, mapping)
-    assert out == mapping
+    assert out['a'] == [1, 2, 3]
+    assert out['b'] == {'z': 1}
 
 
 @pytest.mark.parametrize('constructor', [list, tuple, np.array])

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -588,6 +588,12 @@ def test_expand_raw_dict_nested():
     })
 
 
+def test_envdict_git_ignored_if_git_command_fails_and_no_git_placeholder(
+        tmp_directory):
+    env = EnvDict({'tag': 'value'}, path_to_here='.')
+    assert set(env) == {'cwd', 'here', 'now', 'tag', 'user'}
+
+
 def test_expand_raw_dict_error_if_missing_key():
     mapping = {'another_key': 'value'}
     d = {'some_settting': '{{key}}'}

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -20,6 +20,7 @@ from ploomber.env.expand import (EnvironmentExpander, expand_raw_dictionary,
                                  expand_raw_dictionaries_and_extract_tags)
 from ploomber.util import default
 from ploomber import repo
+from ploomber.exceptions import BaseException
 
 
 def test_env_repr_and_str(cleanup_env, monkeypatch):
@@ -198,14 +199,35 @@ def test_expand_version(cleanup_env):
     assert env.version == 'VERSION'
 
 
-def test_expand_git(monkeypatch, cleanup_env):
-    def mockreturn(module_path):
-        return {'git_location': 'some_version_string'}
+def test_expand_git_with_underscode_module(monkeypatch, cleanup_env):
+    monkeypatch.setattr(repo, 'git_location', lambda _: 'git-location')
+    monkeypatch.setattr(repo, 'git_hash', lambda _: 'git-hash')
 
-    monkeypatch.setattr(repo, 'get_git_info', mockreturn)
+    env = Env({
+        '_module': 'test_pkg',
+        'git': '{{git}}',
+        'git_hash': '{{git_hash}}',
+    })
 
-    env = Env({'_module': 'test_pkg', 'git': '{{git}}'})
-    assert env.git == 'some_version_string'
+    assert env.git == 'git-location'
+    assert env.git_hash == 'git-hash'
+
+
+def test_expand_git(monkeypatch, cleanup_env, tmp_git):
+    monkeypatch.setattr(repo, 'git_location', lambda _: 'git-location')
+    monkeypatch.setattr(repo, 'git_hash', lambda _: 'git-hash')
+
+    Path('env.yaml').write_text(
+        yaml.dump({
+            'git': '{{git}}',
+            'git_hash': '{{git_hash}}',
+        }))
+
+    # need to initialize from a file for this to work, since Env will use
+    # the env.yaml location to run the git command
+    env = Env('env.yaml')
+    assert env.git == 'git-location'
+    assert env.git_hash == 'git-hash'
 
 
 def test_can_create_env_from_dict(cleanup_env):
@@ -446,10 +468,14 @@ def test_error_if_no_project_root(tmp_directory):
     raw = {'root': '{{root}}'}
     expander = EnvironmentExpander(preprocessed={})
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(BaseException) as excinfo:
         expander.expand_raw_dictionary(raw)
 
-    assert 'Failed to expand {{root}}' in str(excinfo.value)
+    assert ('An error happened while expanding placeholder {{root}}'
+            in str(excinfo.getrepr()))
+
+    assert ('could not find a setup.py in a parent folder'
+            in str(excinfo.getrepr()))
 
 
 def test_root_expands_relative_to_path_to_here(tmp_directory):
@@ -596,7 +622,7 @@ def test_envdict_git_ignored_if_git_command_fails_and_no_git_placeholder(
 
 def test_expand_raw_dict_error_if_missing_key():
     mapping = {'another_key': 'value'}
-    d = {'some_settting': '{{key}}'}
+    d = {'some_stuff': '{{key}}'}
 
     with pytest.raises(KeyError) as excinfo:
         expand_raw_dictionary(d, mapping)
@@ -772,3 +798,24 @@ def test_find(tmp_directory):
 
     assert env.cwd == str(Path('.').resolve())
     assert env.here == expected_here
+
+
+@pytest.mark.parametrize('value, error', [
+    ['{{git}}', 'Ensure git is installed and git repository exists'],
+    ['{{git_hash}}', 'Ensure git is installed and git repository exists'],
+    ['{{here}}', 'Ensure the spec was initialized from a file'],
+    ['{{root}}', 'Ensure a pipeline.yaml or setup.py exist'],
+    ['{{another}}', 'Ensure the placeholder is defined'],
+])
+def test_error_message_if_missing_default_placeholder(tmp_directory, value,
+                                                      error):
+    Path('env.yaml').write_text(yaml.dump({'key': 'value'}))
+
+    env = EnvDict('env.yaml')
+
+    with pytest.raises(BaseException) as excinfo:
+        expand_raw_dictionary({
+            'a': value,
+        }, env)
+
+    assert error in str(excinfo.value)

--- a/tests/env/test_sample_project_expanders.py
+++ b/tests/env/test_sample_project_expanders.py
@@ -41,8 +41,7 @@ def test_error_on_unknown_placeholder():
 def test_error_on_git_placeholder_if_missing_underscore_module():
     expander = EnvironmentExpander({})
 
-    with pytest.raises(KeyError) as excinfo:
+    with pytest.raises(BaseException) as excinfo:
         expander.expand_raw_value('{{git}}', parents=[])
 
-    assert ("'_module key is required to use git placeholder'" == str(
-        excinfo.value))
+    assert ("could not locate a git repository" in str(excinfo.value))

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -883,7 +883,9 @@ def test_git_placeholder_and_git_not_installed(monkeypatch, tmp_directory,
     with pytest.raises(BaseException) as excinfo:
         DAGSpec('pipeline.yaml')
 
-    assert 'git is not installed' in str(excinfo.value)
+    expected = ('git is not installed'
+                if save_env_yaml else 'Ensure git is installed')
+    assert expected in str(excinfo.value)
 
 
 @pytest.mark.parametrize('save_env_yaml', [True, False])
@@ -911,7 +913,9 @@ def test_git_placeholder_and_not_in_git_repository(tmp_directory,
     with pytest.raises(BaseException) as excinfo:
         DAGSpec('pipeline.yaml')
 
-    assert 'could not locate a git repository' in str(excinfo.value)
+    expected = ('could not locate a git repository'
+                if save_env_yaml else 'Ensure git is installed')
+    assert expected in str(excinfo.value)
 
 
 @pytest.mark.parametrize('method, kwargs', [

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -914,7 +914,6 @@ def test_git_placeholder_and_not_in_git_repository(tmp_directory,
     assert 'could not locate a git repository' in str(excinfo.value)
 
 
-
 @pytest.mark.parametrize('method, kwargs', [
     [None, dict(data='pipeline.yaml')],
     ['find', dict()],

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -9,7 +9,7 @@ import pandas as pd
 from pathlib import Path
 import pytest
 import yaml
-from conftest import _path_to_tests, fixture_tmp_dir
+from conftest import _path_to_tests, fixture_tmp_dir, git_init
 import getpass
 from copy import deepcopy
 
@@ -28,7 +28,8 @@ from ploomber.tasks import SQLScript
 from ploomber import exceptions
 from ploomber.executors import Serial, Parallel
 from ploomber.products import MetaProduct
-from ploomber.exceptions import DAGSpecInitializationError, ValidationError
+from ploomber.exceptions import (DAGSpecInitializationError, ValidationError,
+                                 BaseException)
 from ploomber.sources.nb_utils import find_cell_with_tag
 
 
@@ -761,7 +762,7 @@ def test_expand_env(save, tmp_directory):
                 'product': 'output.ipynb',
                 'params': {
                     'sample': '{{sample}}',
-                    'user': '{{user}}'
+                    'user': '{{user}}',
                 }
             }]
         },
@@ -769,6 +770,38 @@ def test_expand_env(save, tmp_directory):
 
     assert spec['tasks'][0]['params']['sample'] is True
     assert spec['tasks'][0]['params']['user'] == getpass.getuser()
+
+
+@pytest.mark.parametrize('save', [True, False])
+def test_expand_env_from_file(save, tmp_directory):
+    env = {'sample': True, 'user': '{{user}}', 'git': '{{git}}'}
+
+    if save:
+        with open('env.yaml', 'w') as f:
+            yaml.dump(env, f)
+        env = 'env.yaml'
+
+    spec_ = {
+        'tasks': [{
+            'source': 'plot.py',
+            'product': 'output.ipynb',
+            'params': {
+                'sample': '{{sample}}',
+                'user': '{{user}}',
+                'git': '{{git}}',
+            }
+        }]
+    }
+
+    Path('pipeline.yaml').write_text(yaml.dump(spec_))
+
+    git_init()
+
+    spec = DAGSpec('pipeline.yaml', env=env)
+
+    assert spec['tasks'][0]['params']['sample'] is True
+    assert spec['tasks'][0]['params']['user'] == getpass.getuser()
+    assert spec['tasks'][0]['params']['git'] == 'mybranch'
 
 
 def test_expand_built_in_placeholders(tmp_directory, monkeypatch):
@@ -796,12 +829,15 @@ def test_expand_built_in_placeholders(tmp_directory, monkeypatch):
                 'data': str(Path('{{here}}', 'data.csv')),
             },
             'params': {
-                'now': '{{now}}'
+                'now': '{{now}}',
+                'git': '{{git}}',
             }
         }]
     }
 
     Path('src', 'pkg', 'pipeline.yaml').write_text(yaml.dump(spec_dict))
+
+    git_init()
 
     os.chdir(Path('src', 'pkg'))
 
@@ -809,11 +845,74 @@ def test_expand_built_in_placeholders(tmp_directory, monkeypatch):
     task = spec.data['tasks'][0]
 
     assert task['params']['now'] == 'current-timestamp'
+    assert task['params']['git'] == 'mybranch'
     assert task['source'] == Path(tmp_directory, 'script.py')
     assert task['product']['nb'] == str(
         Path(tmp_directory, 'src', 'pkg', 'username', 'nb.html'))
     assert task['product']['data'] == str(
         Path(tmp_directory, 'src', 'pkg', 'data.csv'))
+
+
+@pytest.mark.parametrize('save_env_yaml', [True, False])
+def test_git_placeholder_and_git_not_installed(monkeypatch, tmp_directory,
+                                               save_env_yaml):
+    if save_env_yaml:
+        with open('env.yaml', 'w') as f:
+            yaml.dump({'some_tag': '{{git}}'}, f)
+
+    # simulate git not installed
+    monkeypatch.setattr(expand.shutil, "which", lambda _: None)
+
+    spec_dict = {
+        'tasks': [{
+            'source': str(Path('tasks', 'script.py')),
+            'product': {
+                'nb': str(Path('out', 'nb.html')),
+                'data': str(Path('out', 'data.csv')),
+            },
+            'params': {
+                'git': '{{git}}' if not save_env_yaml else '{{some_tag}}',
+            }
+        }]
+    }
+
+    Path('pipeline.yaml').write_text(yaml.dump(spec_dict))
+
+    git_init()
+
+    with pytest.raises(BaseException) as excinfo:
+        DAGSpec('pipeline.yaml')
+
+    assert 'git is not installed' in str(excinfo.value)
+
+
+@pytest.mark.parametrize('save_env_yaml', [True, False])
+def test_git_placeholder_and_not_in_git_repository(tmp_directory,
+                                                   save_env_yaml):
+    if save_env_yaml:
+        with open('env.yaml', 'w') as f:
+            yaml.dump({'some_tag': '{{git}}'}, f)
+
+    spec_dict = {
+        'tasks': [{
+            'source': str(Path('tasks', 'script.py')),
+            'product': {
+                'nb': str(Path('out', 'nb.html')),
+                'data': str(Path('out', 'data.csv')),
+            },
+            'params': {
+                'git': '{{git}}' if not save_env_yaml else '{{some_tag}}',
+            }
+        }]
+    }
+
+    Path('pipeline.yaml').write_text(yaml.dump(spec_dict))
+
+    with pytest.raises(BaseException) as excinfo:
+        DAGSpec('pipeline.yaml')
+
+    assert 'could not locate a git repository' in str(excinfo.value)
+
 
 
 @pytest.mark.parametrize('method, kwargs', [

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -7,16 +7,21 @@ from conftest import git_init
 
 
 def test_is_repo_false(tmp_directory):
-    assert not repo.is_repo('')
+    assert not repo.is_repo('.')
 
 
 def test_is_repo_none(tmp_directory):
     assert not repo.is_repo(None)
 
 
+def test_is_repo_no_commits(tmp_directory):
+    subprocess.run(['git', 'init', '-b', 'mybranch'])
+    assert not repo.is_repo('.')
+
+
 def test_is_repo(tmp_directory):
     git_init()
-    assert repo.is_repo('')
+    assert repo.is_repo('.')
 
 
 def test_git_summary(tmp_git):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,3 +1,6 @@
+import subprocess
+from pathlib import Path
+
 from ploomber import repo
 
 from conftest import git_init
@@ -14,6 +17,54 @@ def test_is_repo_none(tmp_directory):
 def test_is_repo(tmp_directory):
     git_init()
     assert repo.is_repo('')
+
+
+def test_git_summary(tmp_git):
+    assert (repo.get_git_summary('.') == repo._run_command(
+        '.', command='git show --oneline -s'))
+
+
+def test_git_hash_on_clean_commit(tmp_git):
+    assert repo.git_hash('.') == repo._run_command(
+        '.', command='git describe --always')
+
+
+def test_git_hash_on_dirty_commit(tmp_git):
+    Path('another').touch()
+    subprocess.run(['git', 'add', '--all'])
+
+    hash_ = repo._run_command('.', command='git describe --always')
+    assert repo.git_hash('.') == f'{hash_}-dirty'
+
+
+def test_git_hash_on_tag(tmp_git):
+    subprocess.run(['git', 'tag', 'my-tag'])
+    assert repo.git_hash('.') == 'my-tag'
+
+
+def test_git_location_branch_tip(tmp_git):
+    subprocess.run(['git', 'tag', 'my-tag'])
+    assert repo.git_location('.') == 'mybranch'
+
+
+def test_git_location_detached_head(tmp_git):
+    Path('another').touch()
+    subprocess.run(['git', 'add', '--all'])
+    subprocess.run(['git', 'commit', '-m', 'another'])
+    subprocess.run(['git', 'checkout', 'HEAD~1'])
+
+    hash_ = repo._run_command('.', command='git describe --always')
+    assert repo.git_location('.') == hash_
+
+
+def test_git_location_detached_head_tag(tmp_git):
+    Path('another').touch()
+    subprocess.run(['git', 'add', '--all'])
+    subprocess.run(['git', 'commit', '-m', 'another'])
+    subprocess.run(['git', 'checkout', 'HEAD~1'])
+    subprocess.run(['git', 'tag', 'my-tag'])
+
+    assert repo.git_location('.') == 'my-tag'
 
 
 def test_is_repo_git_not_installed(tmp_directory, monkeypatch):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -20,6 +20,7 @@ def test_is_repo_no_commits(tmp_directory):
 
 
 def test_is_repo(tmp_directory):
+    Path('file').touch()
     git_init()
     assert repo.is_repo('.')
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,8 +1,29 @@
-from ploomber.repo import get_git_info
+from ploomber import repo
+
+from conftest import git_init
+
+
+def test_is_repo_false(tmp_directory):
+    assert not repo.is_repo('')
+
+
+def test_is_repo_none(tmp_directory):
+    assert not repo.is_repo(None)
+
+
+def test_is_repo(tmp_directory):
+    git_init()
+    assert repo.is_repo('')
+
+
+def test_is_repo_git_not_installed(tmp_directory, monkeypatch):
+    monkeypatch.setattr(repo.shutil, 'which', lambda _: False)
+    git_init()
+    assert not repo.is_repo('')
 
 
 def test_get_git_info():
-    git_info = get_git_info('.')
+    git_info = repo.get_git_info('.')
     assert set(git_info) == {
         'git_summary', 'git_hash', 'git_diff', 'git_timestamp', 'git_branch',
         'git_location'


### PR DESCRIPTION
This PR improves the `{{git}}` placeholder feature:

* Adds `{{git_hash}}` which is slightly different in behavior
* Outputs better error messages (e.g. git not installed, not in a valid repo)
* No longer requires an `env.yaml`: the placeholder can be directly used in `pipeline.yaml`

For a usage example, see: https://github.com/ploomber/projects/blob/versioning/guides/versioning/README.ipynb