### PR TITLE
Added validation checks for import_tasks_from

### DIFF
--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -329,6 +329,15 @@ class DAGSpec(MutableMapping):
                 imported = yaml.safe_load(
                     Path(self.data['meta']['import_tasks_from']).read_text())
 
+                if imported is None:
+                    imported = []
+
+                if not isinstance(imported, list):
+                    raise TypeError(
+                        'Expected list when loading YAML file from '
+                        'import_tasks_from: file.yaml, '
+                        f'but got {type(imported)}')
+
                 if self.env is not None:
                     (imported,
                      tags_other) = expand_raw_dictionaries_and_extract_tags(
@@ -627,6 +636,7 @@ class DAGSpecPartial(DAGSpec):
     A DAGSpec subclass that initializes from a list of tasks (used in the
     onlinedag.py) module
     """
+
     def __init__(self, path_to_partial, env=None):
         with open(path_to_partial) as f:
             tasks = yaml.safe_load(f)

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -636,7 +636,6 @@ class DAGSpecPartial(DAGSpec):
     A DAGSpec subclass that initializes from a list of tasks (used in the
     onlinedag.py) module
     """
-
     def __init__(self, path_to_partial, env=None):
         with open(path_to_partial) as f:
             tasks = yaml.safe_load(f)

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -639,7 +639,6 @@ class DAGSpecPartial(DAGSpec):
     A DAGSpec subclass that initializes from a list of tasks (used in the
     onlinedag.py) module
     """
-
     def __init__(self, path_to_partial, env=None):
         with open(path_to_partial) as f:
             tasks = yaml.safe_load(f)

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -329,8 +329,11 @@ class DAGSpec(MutableMapping):
                 imported = yaml.safe_load(
                     Path(self.data['meta']['import_tasks_from']).read_text())
 
-                if imported is None:
-                    imported = []
+                if not imported:
+                    path = str(self.data['meta']['import_tasks_from'])
+                    raise ValueError('expected import_tasks_from file '
+                                     f'({path!r}) to return a list of tasks, '
+                                     f'got: {imported}')
 
                 if not isinstance(imported, list):
                     raise TypeError(
@@ -636,6 +639,7 @@ class DAGSpecPartial(DAGSpec):
     A DAGSpec subclass that initializes from a list of tasks (used in the
     onlinedag.py) module
     """
+
     def __init__(self, path_to_partial, env=None):
         with open(path_to_partial) as f:
             tasks = yaml.safe_load(f)

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -34,7 +34,6 @@ from ploomber.sources.nb_utils import find_cell_with_tag
 
 
 def create_engine_with_schema(schema):
-
     def fake_create_engine(*args, **kwargs):
         if 'sqlite' in args[0]:
             return create_engine(*args, **kwargs)

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -1128,6 +1128,34 @@ def test_import_tasks_from(tmp_nbs):
         str(t['source']) for t in spec['tasks']
     ]
 
+def test_import_tasks_from_empty_yaml_file(tmp_nbs):
+    Path('some_tasks.yaml').write_text('')
+
+    spec_d = yaml.safe_load(Path('pipeline.yaml').read_text())
+    spec_d['meta']['import_tasks_from'] = 'some_tasks.yaml'
+
+    Path('pipeline.yaml').write_text(yaml.dump(spec_d))
+
+    spec = DAGSpec('pipeline.yaml')
+
+def test_import_tasks_from_non_list_yaml_file(tmp_nbs):
+    with pytest.raises(TypeError):
+        some_tasks = {'source': 'extra_task.py', 'product': 'extra.ipynb'}
+        Path('some_tasks.yaml').write_text(yaml.dump(some_tasks))
+        Path('extra_task.py').write_text("""
+    # + tags=["parameters"]
+    # -
+    """)
+
+        spec_d = yaml.safe_load(Path('pipeline.yaml').read_text())
+        spec_d['meta']['import_tasks_from'] = 'some_tasks.yaml'
+
+        spec = DAGSpec(spec_d)
+
+        spec.to_dag().render()
+        assert str(Path('extra_task.py').resolve()) in [
+            str(t['source']) for t in spec['tasks']
+        ]
 
 def test_import_tasks_from_does_not_resolve_dotted_paths(tmp_nbs):
     """

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -1130,29 +1130,25 @@ def test_import_tasks_from(tmp_nbs):
 
 
 def test_import_tasks_from_empty_yaml_file(tmp_nbs):
+    Path('some_tasks.yaml').write_text('')
+
+    spec_d = yaml.safe_load(Path('pipeline.yaml').read_text())
+    spec_d['meta']['import_tasks_from'] = 'some_tasks.yaml'
+
     with pytest.raises(ValueError) as excinfo:
-        Path('some_tasks.yaml').write_text('')
-
-        spec_d = yaml.safe_load(Path('pipeline.yaml').read_text())
-        spec_d['meta']['import_tasks_from'] = 'some_tasks.yaml'
-
-        spec = DAGSpec(spec_d)
-
-        spec.to_dag().render()
+        DAGSpec(spec_d)
     assert 'expected import_tasks_from' in str(excinfo.value)
 
 
 def test_import_tasks_from_non_list_yaml_file(tmp_nbs):
+    some_tasks = {'source': 'extra_task.py', 'product': 'extra.ipynb'}
+    Path('some_tasks.yaml').write_text(yaml.dump(some_tasks))
+
+    spec_d = yaml.safe_load(Path('pipeline.yaml').read_text())
+    spec_d['meta']['import_tasks_from'] = 'some_tasks.yaml'
+
     with pytest.raises(TypeError) as excinfo:
-        some_tasks = {'source': 'extra_task.py', 'product': 'extra.ipynb'}
-        Path('some_tasks.yaml').write_text(yaml.dump(some_tasks))
-
-        spec_d = yaml.safe_load(Path('pipeline.yaml').read_text())
-        spec_d['meta']['import_tasks_from'] = 'some_tasks.yaml'
-
-        spec = DAGSpec(spec_d)
-
-        spec.to_dag().render()
+        DAGSpec(spec_d)
     assert 'Expected list when loading YAML file' in str(excinfo.value)
 
 


### PR DESCRIPTION
Issue #669
Changes:
When loading `import_tasks_from: file.yaml`
1. If `yaml.safe_load` is None, replace it with an empty list
2. If `yaml.safe_load` returns something other than a list, raise an error saying we were expecting a list