### PR TITLE
Improve error message when NotebookRunner initialized with a String

### DIFF
--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -143,6 +143,7 @@ def requires_path(func):
     Checks if NotebookSource instance was initialized from a file, raises
     an error if not
     """
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
 
@@ -179,6 +180,7 @@ class NotebookSource(Source):
     The render method prepares the notebook for execution: it adds the
     parameters and it makes sure kernelspec is defined
     """
+
     @requires([
         'parso', 'pyflakes', 'jupytext', 'nbformat', 'papermill',
         'jupyter_client'
@@ -266,11 +268,22 @@ class NotebookSource(Source):
         if self._path is not None and ext_in is None:
             self._ext_in = self._path.suffix[1:]
         elif self._path is None and ext_in is None:
-            raise ValueError('"ext_in" cannot be None if the notebook is '
-                             'initialized from a string. Either pass '
-                             'a pathlib.Path object with the notebook file '
-                             'location or pass the source code as string '
-                             'and include the "ext_in" parameter')
+
+            if Path(self._primitive).exists():
+                raise ValueError(
+                    'The file {} you passed in looks like a path to a file.'
+                    'Perhaps you meant passing a pathlib.Path object '
+                    'like this:\n'
+                    'from pathlib import Path'
+                    'NotebookRunner(Path(\'{}\'))'.format(
+                        self._primitive, self._primitive))
+            else:
+                raise ValueError(
+                    '"ext_in" cannot be None if the notebook is '
+                    'initialized from a string. Either pass '
+                    'a pathlib.Path object with the notebook file '
+                    'location or pass the source code as string '
+                    'and include the "ext_in" parameter')
         elif self._path is not None and ext_in is not None:
             raise ValueError('"ext_in" must be None if notebook is '
                              'initialized from a pathlib.Path object')

--- a/tests/sources/test_notebooksource.py
+++ b/tests/sources/test_notebooksource.py
@@ -933,3 +933,13 @@ def test_error_if_last_cell_in_nb_is_the_parameters_cell(tmp_directory):
 
     assert 'nb.ipynb' in str(excinfo.value)
     assert 'Add a new cell with your code.' in str(excinfo.value)
+
+
+def test_error_if_source_str_like_path(tmp_directory):
+    Path('script.py').touch()
+
+    with pytest.raises(ValueError) as excinfo:
+        NotebookSource('script.py')
+
+    assert 'Perhaps you meant passing a pathlib.Path object' in str(
+        excinfo.value)

--- a/tests/tasks/test_notebook.py
+++ b/tests/tasks/test_notebook.py
@@ -958,3 +958,14 @@ def test_replaces_existing_product(tmp_directory):
 
     # this will fail on windows if we don't remove the existing file first
     dag.build()
+
+
+def test_initialize_with_str_like_path(tmp_directory):
+    Path('script.py').touch()
+    dag = DAG()
+
+    with pytest.raises(ValueError) as excinfo:
+        NotebookRunner('script.py', File('out.html'), dag=dag)
+
+    assert 'Perhaps you meant passing a pathlib.Path object' in str(
+        excinfo.value)


### PR DESCRIPTION
### Description

This CR includes changes that make `NotebookRunner` initialized with a String explicitly throw an exception if the string looks like a `pathlib.Path`

### Tests

```sh
$ pytest tests/sources/test_notebooksource.py -k 'test_error_if_source_str_like_path'
============================================================ test session starts ============================================================
platform linux -- Python 3.7.11, pytest-7.1.1, pluggy-1.0.0
rootdir: /home/vagrant/ploomber, configfile: pyproject.toml
plugins: cov-3.0.0, anyio-3.5.0
collected 87 items / 86 deselected / 1 selected

tests/sources/test_notebooksource.py .                                                                                                [100%]

================================================ 1 passed, 86 deselected, 1 warning in 0.32s ================================================
```

```sh
$ pytest tests/tasks/test_notebook.py  -k 'test_initialize_with_str_like_path'
============================================================ test session starts ============================================================
platform linux -- Python 3.7.11, pytest-7.1.1, pluggy-1.0.0
rootdir: /home/vagrant/ploomber, configfile: pyproject.toml
plugins: cov-3.0.0, anyio-3.5.0
collected 69 items / 68 deselected / 1 selected

tests/tasks/test_notebook.py .                                                                                                        [100%]

================================================ 1 passed, 68 deselected, 1 warning in 0.12s ================================================
```

### Related Issue

https://github.com/ploomber/ploomber/issues/694