### PR TITLE
Refactors config files

### DIFF
--- a/src/ploomber/config.py
+++ b/src/ploomber/config.py
@@ -29,7 +29,7 @@ class Config(abc.ABC):
             try:
                 content = yaml.safe_load(text)
                 loaded = True
-            except Exception as e:
+            except Exception:
                 warnings.warn(f'Error loading {str(path)!r}, '
                               'reverting to default values')
                 loaded = False

--- a/src/ploomber/config.py
+++ b/src/ploomber/config.py
@@ -30,12 +30,14 @@ class Config(abc.ABC):
                 content = yaml.safe_load(text)
                 loaded = True
             except Exception as e:
-                warnings.warn(str(e))
+                warnings.warn(f'Error loading {str(path)!r}, '
+                              'reverting to default values')
                 loaded = False
                 content = self._get_data()
 
             if loaded and not isinstance(content, Mapping):
-                warnings.warn('YAMl not a mapping')
+                warnings.warn(f'Error loading {str(path)!r}. Content is not'
+                              'a dictionary, reverting to default values')
                 content = self._get_data()
 
             self._set_data(content)

--- a/src/ploomber/config.py
+++ b/src/ploomber/config.py
@@ -6,7 +6,7 @@ import yaml
 
 
 class Config(abc.ABC):
-    """And abstract class to create configuration files (stored as YAML)
+    """An abstract class to create configuration files (stored as YAML)
 
     Notes
     -----

--- a/src/ploomber/config.py
+++ b/src/ploomber/config.py
@@ -1,0 +1,59 @@
+import abc
+from collections.abc import Mapping
+
+import yaml
+
+
+class Config(abc.ABC):
+    def __init__(self):
+        # resolve home directory
+        path = self.path()
+
+        if not path.exists():
+            defaults = self._get_data()
+            path.write_text(yaml.dump(defaults))
+            self._set_data(defaults)
+        else:
+            text = path.read_text()
+
+            try:
+                content = yaml.safe_load(text)
+                loaded = True
+            except Exception:
+                # NOTE: show warning?
+                loaded = False
+                content = self._get_data()
+
+            if loaded and not isinstance(content, Mapping):
+                # NOTE: show warning?
+                content = self._get_data()
+
+            self._set_data(content)
+
+    # TODO: delete, only here for compatibility
+    def read(self):
+        return self._get_data()
+
+    def _get_data(self):
+        return {key: getattr(self, key) for key in self.__annotations__}
+
+    def _set_data(self, data):
+        for key in self.__annotations__:
+            if key in data:
+                setattr(self, key, data[key])
+
+    def _write(self):
+        path = self.path()
+        data = self._get_data()
+        path.write_text(yaml.dump(data))
+
+    def __setattr__(self, name, value):
+        if name not in self.__annotations__:
+            raise ValueError(f'{name} not a valid field')
+        else:
+            super().__setattr__(name, value)
+            self._write()
+
+    @abc.abstractclassmethod
+    def path(cls):
+        pass

--- a/src/ploomber/config.py
+++ b/src/ploomber/config.py
@@ -6,6 +6,13 @@ import yaml
 
 
 class Config(abc.ABC):
+    """And abstract class to create configuration files (stored as YAML)
+
+    Notes
+    -----
+    For examples, see test_config.py or the concrete classes
+    (UserSettings, Internal)
+    """
     def __init__(self):
         self._init_values()
 
@@ -33,21 +40,28 @@ class Config(abc.ABC):
 
             self._set_data(content)
 
-    # TODO: delete, only here for compatibility
-    def read(self):
-        return self._get_data()
-
     def _get_data(self):
+        """Extract values from the annotations and return a dictionary
+        """
         return {key: getattr(self, key) for key in self.__annotations__}
 
     def _set_data(self, data):
+        """Take a dictionary and store it in the annotations
+        """
         for key in self.__annotations__:
             if key in data:
                 setattr(self, key, data[key])
 
     def _init_values(self):
+        """
+        Iterate over annotations to initialize values. This is only relevant
+        when any of the annotations has a factory method to initialize the
+        values. If they value is a literal, no changes happen.
+        """
         for key in self.__annotations__:
             name = f'{key}_default'
+
+            # if there is a method with such name, call it and store the output
             if hasattr(self, name):
                 value = getattr(self, name)()
                 # call __setattr__ on the superclass so we skip the part
@@ -56,9 +70,10 @@ class Config(abc.ABC):
                 super().__setattr__(key, value)
 
     def _write(self):
-        path = self.path()
+        """Writes data to the YAML file
+        """
         data = self._get_data()
-        path.write_text(yaml.dump(data))
+        self.path().write_text(yaml.dump(data))
 
     def __setattr__(self, name, value):
         if name not in self.__annotations__:
@@ -69,4 +84,6 @@ class Config(abc.ABC):
 
     @abc.abstractclassmethod
     def path(cls):
+        """Returns the path to the YAML file
+        """
         pass

--- a/src/ploomber/telemetry/telemetry.py
+++ b/src/ploomber/telemetry/telemetry.py
@@ -40,12 +40,10 @@ import platform
 
 import click
 import posthog
-import distro
 
 from ploomber.telemetry import validate_inputs
 from ploomber.config import Config
 from ploomber import __version__
-
 
 TELEMETRY_VERSION = '0.3'
 DEFAULT_HOME_DIR = '~/.ploomber'

--- a/src/ploomber/telemetry/telemetry.py
+++ b/src/ploomber/telemetry/telemetry.py
@@ -31,20 +31,19 @@ The data we collect is limited to:
 import datetime
 import http.client as httplib
 import json
-import warnings
 import os
 from pathlib import Path
 import sys
-import uuid
+from uuid import uuid4
 from functools import wraps
 import platform
 
 import click
 import posthog
-import yaml
 import distro
 
 from ploomber.telemetry import validate_inputs
+from ploomber.config import Config
 from ploomber import __version__
 
 TELEMETRY_VERSION = '0.3'
@@ -56,18 +55,15 @@ posthog.project_api_key = 'phc_P9SpSeypyPwxrMdFn2edOOEooQioF2axppyEeDwtMSP'
 PLOOMBER_HOME_DIR = os.getenv("PLOOMBER_HOME_DIR")
 
 
-class Config:
-    def read(self):
-        return read_conf_file(self.path())
-
-    def write(self, data, error=False):
-        write_conf_file(self.path(), data, error=error)
-
-
 class UserSettings(Config):
     """User-customizable settings
     """
-    def path(self):
+    version_check_enabled: bool = True
+    cloud_key: str = None
+    stats_enabled: bool = True
+
+    @classmethod
+    def path(cls):
         return Path(check_dir_exist(CONF_DIR), DEFAULT_USER_CONF)
 
 
@@ -76,28 +72,16 @@ class Internal(Config):
     Internal file to store settings (not intended to be modified by the
     user)
     """
-    def path(self):
+    last_version_check: str = None
+    uid: str
+    first_time: bool = True
+
+    @classmethod
+    def path(cls):
         return Path(check_dir_exist(CONF_DIR), DEFAULT_PLOOMBER_CONF)
 
-
-def read_conf_file(conf_path):
-    try:
-        with conf_path.open("r") as file:
-            conf = yaml.safe_load(file)
-            return conf
-    except Exception as e:
-        warnings.warn(f"Can't read config file {e}")
-        return {}
-
-
-def write_conf_file(conf_path, to_write, error=None):
-    try:  # Create for future runs
-        with conf_path.open("w") as file:
-            yaml.dump(to_write, file)
-    except Exception as e:
-        warnings.warn(f"Can't write to config file: {e}")
-        if error:
-            return e
+    def uid_default(self):
+        return str(uuid4())
 
 
 def python_version():
@@ -119,8 +103,9 @@ def is_online():
         conn.close()
 
 
-# Will output if the code is within a container
 def is_docker():
+    """Will output if the code is within a container
+    """
     try:
         cgroup = Path('/proc/self/cgroup')
         docker_env = Path('/.dockerenv')
@@ -184,7 +169,8 @@ def is_conda():
 def get_base_prefix_compat():
     """
     This function will find the pip virtualenv with different python versions.
-    Get base/real prefix, or sys.prefix if there is none."""
+    Get base/real prefix, or sys.prefix if there is none.
+    """
     return getattr(sys, "base_prefix", None) or sys.prefix or getattr(
         sys, "real_prefix", None)
 
@@ -294,23 +280,7 @@ def check_dir_exist(input_location=None):
     return p
 
 
-def check_uid():
-    """
-    Checks if local user id exists as a uid file, creates if not.
-    """
-    internal = Internal()
-    conf = internal.read()  # file already exist due to version check
-    if 'uid' not in conf.keys():
-        uid = str(uuid.uuid4())
-        res = internal.write({"uid": uid}, error=True)
-        if res:
-            return f"NO_UID {res}"
-        else:
-            return uid
-    return conf.get('uid', "NO_UID")
-
-
-def check_stats_enabled():
+def check_telemetry_enabled():
     """
     Check if the user allows us to use telemetry. In order of precedence:
 
@@ -321,14 +291,7 @@ def check_stats_enabled():
         return os.environ['PLOOMBER_STATS_ENABLED'].lower() == 'true'
 
     settings = UserSettings()
-    # Check if local config exists
-    config_path = settings.path()
-    if not config_path.exists():
-        settings.write({"stats_enabled": True})
-        return True
-    else:  # read and return config
-        conf = settings.read()
-        return conf.get('stats_enabled', True)
+    return settings.stats_enabled
 
 
 def check_first_time_usage():
@@ -336,9 +299,10 @@ def check_first_time_usage():
     The function checks for first time usage if the conf file exists and the
     uid file doesn't exist.
     """
-    config_path = UserSettings().path()
-    uid_conf = Internal().read()
-    return config_path.exists() and 'uid' not in uid_conf.keys()
+    internal = Internal()
+    first_time = internal.first_time
+    internal.first_time = False
+    return first_time
 
 
 def get_latest_version():
@@ -359,20 +323,14 @@ def get_latest_version():
         conn.close()
 
 
-def update_conf_file(conf_path, to_write, error=None):
-    conf = read_conf_file(conf_path)
-    new_conf = dict(conf, **to_write)
-    write_conf_file(conf_path, new_conf, error)
-
-
 def is_cloud_user():
     """
         The function checks if the cloud api key is set for the user.
         Checks if the cloud_key is set in the User conf file (config.yaml).
         returns True/False accordingly.
         """
-    conf = UserSettings().read()
-    return conf.get('cloud_key', False)
+    settings = UserSettings()
+    return settings.cloud_key
 
 
 def check_version():
@@ -382,31 +340,17 @@ def check_version():
     If it's not the latest, notifies the user and saves the metadata to conf
     Alerting every 2 days on stale versions
     """
-    # Read conf file
-    today = datetime.datetime.now()
-    conf = UserSettings().read()
+    settings = UserSettings()
 
-    internal = Internal()
-    version_path = internal.path()
-    # Update version conf if not there
-    if not version_path.exists():
-        version = {'last_version_check': today}
-    else:
-        version = internal.read()
-        if 'last_version_check' not in version.keys():
-            version['last_version_check'] = today
-
-    internal.write(version)
-
-    # Check if the flag was disabled
-    if conf and 'version_check_enabled' in conf.keys() \
-            and not conf['version_check_enabled']:
+    if not settings.version_check_enabled:
         return
 
+    internal = Internal()
+    now = datetime.datetime.now()
+
     # Check if we already notified in the last 2 days
-    last_message = version['last_version_check']
-    diff = (today - last_message).days
-    if diff < 2:
+    if internal.last_version_check and (now -
+                                        internal.last_version_check).days < 2:
         return
 
     # check latest version (this is an expensive call since it hits pypi.org)
@@ -424,8 +368,7 @@ def check_version():
         fg='yellow')
 
     # Update latest check date
-    version['last_version_check'] = today
-    internal.write(version)
+    internal.last_version_check = now
 
 
 def _get_telemetry_info():
@@ -435,19 +378,18 @@ def _get_telemetry_info():
     for first time installation.
     """
     # Check if telemetry is enabled, if not skip, else check for uid
-    telemetry_enabled = check_stats_enabled()
+    telemetry_enabled = check_telemetry_enabled()
 
     # Check latest version
     check_version()
 
     if telemetry_enabled:
-
         # Check first time install
         is_install = check_first_time_usage()
 
         # if not uid, create
-        uid = check_uid()
-        return telemetry_enabled, uid, is_install
+        internal = Internal()
+        return telemetry_enabled, internal.uid, is_install
     else:
         return False, '', False
 
@@ -469,11 +411,14 @@ def log_api(action, client_time=None, total_runtime=None, metadata=None):
     """
     metadata = metadata or {}
 
-    event_id = uuid.uuid4()
+    event_id = uuid4()
+
     if client_time is None:
         client_time = datetime.datetime.now()
 
     (telemetry_enabled, uid, is_install) = _get_telemetry_info()
+
+    # NOTE: this should not happen anymore
     if 'NO_UID' in uid:
         metadata['uid_issue'] = uid
         uid = None

--- a/src/ploomber/telemetry/telemetry.py
+++ b/src/ploomber/telemetry/telemetry.py
@@ -72,7 +72,7 @@ class Internal(Config):
     Internal file to store settings (not intended to be modified by the
     user)
     """
-    last_version_check: str = None
+    last_version_check: datetime.datetime = None
     uid: str
     first_time: bool = True
 

--- a/src/ploomber/telemetry/telemetry.py
+++ b/src/ploomber/telemetry/telemetry.py
@@ -60,6 +60,9 @@ class Storage:
     def read(self):
         return read_conf_file(self.path())
 
+    def write(self, data, error=False):
+        write_conf_file(self.path(), data, error=error)
+
 
 class Settings(Storage):
     """User-customizable settings
@@ -296,11 +299,10 @@ def check_uid():
     Checks if local user id exists as a uid file, creates if not.
     """
     internal = Internal()
-    uid_path = internal.path()
     conf = internal.read()  # file already exist due to version check
     if 'uid' not in conf.keys():
         uid = str(uuid.uuid4())
-        res = write_conf_file(uid_path, {"uid": uid}, error=True)
+        res = internal.write({"uid": uid}, error=True)
         if res:
             return f"NO_UID {res}"
         else:
@@ -322,7 +324,7 @@ def check_stats_enabled():
     # Check if local config exists
     config_path = settings.path()
     if not config_path.exists():
-        write_conf_file(config_path, {"stats_enabled": True})
+        settings.write({"stats_enabled": True})
         return True
     else:  # read and return config
         conf = settings.read()
@@ -394,7 +396,7 @@ def check_version():
         if 'last_version_check' not in version.keys():
             version['last_version_check'] = today
 
-    write_conf_file(version_path, version)
+    internal.write(version)
 
     # Check if the flag was disabled
     if conf and 'version_check_enabled' in conf.keys() \
@@ -423,7 +425,7 @@ def check_version():
 
     # Update latest check date
     version['last_version_check'] = today
-    write_conf_file(version_path, version)
+    internal.write(version)
 
 
 def _get_telemetry_info():

--- a/src/ploomber/telemetry/telemetry.py
+++ b/src/ploomber/telemetry/telemetry.py
@@ -254,7 +254,7 @@ def check_uid():
     """
     Checks if local user id exists as a uid file, creates if not.
     """
-    uid_path = Path(check_dir_exist(CONF_DIR), DEFAULT_PLOOMBER_CONF)
+    uid_path = path_to_ploomber_config()
     conf = read_conf_file(uid_path)  # file already exist due to version check
     if 'uid' not in conf.keys():
         uid = str(uuid.uuid4())
@@ -277,7 +277,7 @@ def check_stats_enabled():
         return os.environ['PLOOMBER_STATS_ENABLED'].lower() == 'true'
 
     # Check if local config exists
-    config_path = Path(check_dir_exist(CONF_DIR), DEFAULT_USER_CONF)
+    config_path = path_to_user_config()
     if not config_path.exists():
         write_conf_file(config_path, {"stats_enabled": True})
         return True
@@ -291,8 +291,8 @@ def check_first_time_usage():
     The function checks for first time usage if the conf file exists and the
     uid file doesn't exist.
     """
-    config_path = Path(check_dir_exist(CONF_DIR), DEFAULT_USER_CONF)
-    uid_path = Path(check_dir_exist(CONF_DIR), DEFAULT_PLOOMBER_CONF)
+    config_path = path_to_user_config()
+    uid_path = path_to_ploomber_config()
     uid_conf = read_conf_file(uid_path)
     return config_path.exists() and 'uid' not in uid_conf.keys()
 
@@ -325,6 +325,14 @@ def read_conf_file(conf_path):
         return {}
 
 
+def path_to_ploomber_config():
+    return Path(check_dir_exist(CONF_DIR), DEFAULT_PLOOMBER_CONF)
+
+
+def path_to_user_config():
+    return Path(check_dir_exist(CONF_DIR), DEFAULT_USER_CONF)
+
+
 def write_conf_file(conf_path, to_write, error=None):
     try:  # Create for future runs
         with conf_path.open("w") as file:
@@ -347,7 +355,7 @@ def is_cloud_user():
         Checks if the cloud_key is set in the User conf file (config.yaml).
         returns True/False accordingly.
         """
-    user_conf_path = Path(check_dir_exist(CONF_DIR), DEFAULT_USER_CONF)
+    user_conf_path = path_to_user_config()
     conf = read_conf_file(user_conf_path)
     return conf.get('cloud_key', False)
 
@@ -361,10 +369,10 @@ def check_version():
     """
     # Read conf file
     today = datetime.datetime.now()
-    config_path = Path(check_dir_exist(CONF_DIR), DEFAULT_USER_CONF)
+    config_path = path_to_user_config()
     conf = read_conf_file(config_path)
 
-    version_path = Path(check_dir_exist(CONF_DIR), DEFAULT_PLOOMBER_CONF)
+    version_path = path_to_ploomber_config()
     # Update version conf if not there
     if not version_path.exists():
         version = {'last_version_check': today}

--- a/src/ploomber/telemetry/telemetry.py
+++ b/src/ploomber/telemetry/telemetry.py
@@ -287,10 +287,6 @@ def check_stats_enabled():
         return conf.get('stats_enabled', True)
 
 
-def set_api_key(api_key):
-    print()
-
-
 def check_first_time_usage():
     """
     The function checks for first time usage if the conf file exists and the

--- a/src/ploomber/telemetry/telemetry.py
+++ b/src/ploomber/telemetry/telemetry.py
@@ -255,7 +255,7 @@ def check_uid():
     Checks if local user id exists as a uid file, creates if not.
     """
     uid_path = path_to_ploomber_config()
-    conf = read_conf_file(uid_path)  # file already exist due to version check
+    conf = read_ploomber_config()  # file already exist due to version check
     if 'uid' not in conf.keys():
         uid = str(uuid.uuid4())
         res = write_conf_file(uid_path, {"uid": uid}, error=True)
@@ -282,7 +282,7 @@ def check_stats_enabled():
         write_conf_file(config_path, {"stats_enabled": True})
         return True
     else:  # read and return config
-        conf = read_conf_file(config_path)
+        conf = read_user_config()
         return conf.get('stats_enabled', True)
 
 
@@ -292,8 +292,7 @@ def check_first_time_usage():
     uid file doesn't exist.
     """
     config_path = path_to_user_config()
-    uid_path = path_to_ploomber_config()
-    uid_conf = read_conf_file(uid_path)
+    uid_conf = read_ploomber_config()
     return config_path.exists() and 'uid' not in uid_conf.keys()
 
 
@@ -329,8 +328,16 @@ def path_to_ploomber_config():
     return Path(check_dir_exist(CONF_DIR), DEFAULT_PLOOMBER_CONF)
 
 
+def read_ploomber_config():
+    return read_conf_file(path_to_ploomber_config())
+
+
 def path_to_user_config():
     return Path(check_dir_exist(CONF_DIR), DEFAULT_USER_CONF)
+
+
+def read_user_config():
+    return read_conf_file(path_to_user_config())
 
 
 def write_conf_file(conf_path, to_write, error=None):
@@ -355,8 +362,7 @@ def is_cloud_user():
         Checks if the cloud_key is set in the User conf file (config.yaml).
         returns True/False accordingly.
         """
-    user_conf_path = path_to_user_config()
-    conf = read_conf_file(user_conf_path)
+    conf = read_user_config()
     return conf.get('cloud_key', False)
 
 
@@ -369,15 +375,14 @@ def check_version():
     """
     # Read conf file
     today = datetime.datetime.now()
-    config_path = path_to_user_config()
-    conf = read_conf_file(config_path)
+    conf = read_user_config()
 
     version_path = path_to_ploomber_config()
     # Update version conf if not there
     if not version_path.exists():
         version = {'last_version_check': today}
     else:
-        version = read_conf_file(version_path)
+        version = read_ploomber_config()
         if 'last_version_check' not in version.keys():
             version['last_version_check'] = today
 

--- a/src/ploomber/telemetry/telemetry.py
+++ b/src/ploomber/telemetry/telemetry.py
@@ -28,25 +28,24 @@ The data we collect is limited to:
     telemetry_version - Telemetry version
 
 """
-
 import datetime
 import http.client as httplib
 import json
 import warnings
-
-import click
-import posthog
-import yaml
 import os
 from pathlib import Path
 import sys
 import uuid
 from functools import wraps
+import platform
+
+import click
+import posthog
+import yaml
+import distro
 
 from ploomber.telemetry import validate_inputs
 from ploomber import __version__
-import platform
-import distro
 
 TELEMETRY_VERSION = '0.3'
 DEFAULT_HOME_DIR = '~/.ploomber'

--- a/src/ploomber/telemetry/telemetry.py
+++ b/src/ploomber/telemetry/telemetry.py
@@ -56,7 +56,7 @@ posthog.project_api_key = 'phc_P9SpSeypyPwxrMdFn2edOOEooQioF2axppyEeDwtMSP'
 PLOOMBER_HOME_DIR = os.getenv("PLOOMBER_HOME_DIR")
 
 
-class Storage:
+class Config:
     def read(self):
         return read_conf_file(self.path())
 
@@ -64,14 +64,14 @@ class Storage:
         write_conf_file(self.path(), data, error=error)
 
 
-class Settings(Storage):
+class UserSettings(Config):
     """User-customizable settings
     """
     def path(self):
         return Path(check_dir_exist(CONF_DIR), DEFAULT_USER_CONF)
 
 
-class Internal(Storage):
+class Internal(Config):
     """
     Internal file to store settings (not intended to be modified by the
     user)
@@ -320,7 +320,7 @@ def check_stats_enabled():
     if 'PLOOMBER_STATS_ENABLED' in os.environ:
         return os.environ['PLOOMBER_STATS_ENABLED'].lower() == 'true'
 
-    settings = Settings()
+    settings = UserSettings()
     # Check if local config exists
     config_path = settings.path()
     if not config_path.exists():
@@ -336,7 +336,7 @@ def check_first_time_usage():
     The function checks for first time usage if the conf file exists and the
     uid file doesn't exist.
     """
-    config_path = Settings().path()
+    config_path = UserSettings().path()
     uid_conf = Internal().read()
     return config_path.exists() and 'uid' not in uid_conf.keys()
 
@@ -371,7 +371,7 @@ def is_cloud_user():
         Checks if the cloud_key is set in the User conf file (config.yaml).
         returns True/False accordingly.
         """
-    conf = Settings().read()
+    conf = UserSettings().read()
     return conf.get('cloud_key', False)
 
 
@@ -384,7 +384,7 @@ def check_version():
     """
     # Read conf file
     today = datetime.datetime.now()
-    conf = Settings().read()
+    conf = UserSettings().read()
 
     internal = Internal()
     version_path = internal.path()

--- a/tests/cli/test_cloud.py
+++ b/tests/cli/test_cloud.py
@@ -91,7 +91,6 @@ def test_write_key_no_conf_file(tmp_directory, monkeypatch):
     with full_path.open("r") as file:
         conf = yaml.safe_load(file)
 
-    assert len(conf.keys()) == 1
     assert key_name in conf.keys()
     assert key_val in conf[key_name]
 
@@ -112,25 +111,19 @@ def test_overwrites_api_key(write_sample_conf):
     assert another_val in conf[key_name]
 
 
-def test_api_key_well_formatted(write_sample_conf):
-    with pytest.warns(Warning) as record:
-        cloud.set_key(None)
+@pytest.mark.parametrize('arg', [None, '12345'])
+def test_api_key_well_formatted(write_sample_conf, arg):
+    with pytest.raises(BaseException) as excinfo:
+        cloud.set_key(arg)
 
-    if not record:
-        pytest.fail("Expected a user warning!")
-
-    with pytest.warns(Warning) as record:
-        cloud.set_key("12345")
-
-    if not record:
-        pytest.fail("Expected a user warning!")
+    assert 'The API key is malformed' in str(excinfo.value)
 
 
 def test_get_api_key(write_sample_conf, capsys):
     key_val = "TEST_KEY12345678987654"
     runner = CliRunner()
     result = runner.invoke(set_key, args=[key_val], catch_exceptions=False)
-    assert 'Key was stored\n' == result.stdout
+    assert 'Key was stored\n' in result.stdout
 
     result = runner.invoke(get_key, catch_exceptions=False)
     assert key_val in result.stdout

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -50,6 +50,48 @@ def ignore_env_var_and_set_tmp_default_home_dir(
     monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
 
 
+def test_user_settings_create_file(tmp_directory, monkeypatch):
+    monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
+
+    settings = telemetry.UserSettings()
+    content = yaml.safe_load(Path('stats', 'config.yaml').read_text())
+
+    assert content == {
+        'cloud_key': None,
+        'stats_enabled': True,
+        'version_check_enabled': True,
+    }
+    assert settings.cloud_key is None
+    assert settings.stats_enabled
+
+
+def test_internal_create_file(tmp_directory, monkeypatch):
+    monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
+    monkeypatch.setattr(telemetry, 'uuid4', lambda: 'some-unique-uuid')
+
+    internal = telemetry.Internal()
+    content = yaml.safe_load(Path('stats', 'uid.yaml').read_text())
+
+    assert content == {
+        'uid': 'some-unique-uuid',
+        'last_version_check': None,
+        'first_time': True
+    }
+    assert internal.uid == 'some-unique-uuid'
+    assert internal.last_version_check is None
+
+
+def test_does_not_overwrite_existing_uid(tmp_directory, monkeypatch):
+    monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
+
+    Path('stats').mkdir()
+    Path('stats', 'uid.yaml').write_text(yaml.dump({'uid': 'existing-uid'}))
+
+    internal = telemetry.Internal()
+
+    assert internal.uid == 'existing-uid'
+
+
 # Validations tests
 def test_str_validation():
     res = str_param("Test", "")
@@ -79,7 +121,7 @@ def test_opt_str_validation():
 
 
 def test_check_stats_enabled(ignore_env_var_and_set_tmp_default_home_dir):
-    stats_enabled = telemetry.check_stats_enabled()
+    stats_enabled = telemetry.check_telemetry_enabled()
     assert stats_enabled is True
 
 
@@ -102,24 +144,18 @@ def test_env_var_takes_precedence(monkeypatch,
                                         stats_enabled: {yaml_value}
                                         """)
 
-    assert telemetry.check_stats_enabled() is expected_first
+    assert telemetry.check_telemetry_enabled() is expected_first
 
     monkeypatch.setenv('PLOOMBER_STATS_ENABLED', env_value, prepend=False)
 
-    assert telemetry.check_stats_enabled() is expected_second
+    assert telemetry.check_telemetry_enabled() is expected_second
 
 
 def test_first_usage(monkeypatch, tmp_directory):
     monkeypatch.setattr(telemetry, 'DEFAULT_HOME_DIR', '.')
 
-    stats = Path('stats')
-    stats.mkdir()
-
-    # This isn't a first time usage since the config file doesn't exist yet.
-    assert not telemetry.check_first_time_usage()
-    (stats / 'config.yaml').write_text("stats_enabled: True")
-
     assert telemetry.check_first_time_usage()
+    assert not telemetry.check_first_time_usage()
 
 
 # The below fixtures are to mock the different virtual environments
@@ -198,11 +234,6 @@ def test_os_type(monkeypatch, os_param):
     monkeypatch.setattr(telemetry.platform, 'system', mock)
     os_type = telemetry.get_os()
     assert os_type == os_param
-
-
-def test_uid_file():
-    uid = telemetry.check_uid()
-    assert isinstance(uid, str)
 
 
 def test_full_telemetry_info(ignore_env_var_and_set_tmp_default_home_dir):
@@ -502,7 +533,7 @@ def test_conf_file_after_version_check(tmp_directory, monkeypatch):
     with version_path.open("r") as file:
         conf = yaml.safe_load(file)
     assert 'uid' in conf.keys()
-    assert len(conf.keys()) == 2
+    assert len(conf.keys()) == 3
 
 
 def test_get_version_timeout():
@@ -571,10 +602,11 @@ def test_user_output_on_different_versions(tmp_directory, capsys, monkeypatch):
 
 
 def test_no_output_latest_version(tmp_directory, capsys, monkeypatch):
-    # The file's date is today now, no error should be raised
+    # The file's date is today now, no output should be displayed
     write_to_conf_file(tmp_directory=tmp_directory,
                        monkeypatch=monkeypatch,
                        last_check=datetime.datetime.now())
+
     telemetry.check_version()
     captured = capsys.readouterr()
     assert "Ploomber version" not in captured.out

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ploomber.config import Config
+
+
+class MyConfig(Config):
+    number: int = 42
+    string: str = 'value'
+
+    def path(self):
+        return Path('myconfig.yaml')
+
+
+def test_stores_defaults(tmp_directory):
+    MyConfig()
+
+    content = yaml.safe_load(Path('myconfig.yaml').read_text())
+
+    assert content == {'number': 42, 'string': 'value'}
+
+
+def test_reads_existing(tmp_directory):
+    path = Path('myconfig.yaml')
+    path.write_text(yaml.dump({'number': 100}))
+
+    cfg = MyConfig()
+
+    assert cfg.number == 100
+    assert cfg.string == 'value'
+
+
+def test_ignores_extra(tmp_directory):
+    path = Path('myconfig.yaml')
+    path.write_text(
+        yaml.dump({
+            'number': 200,
+            'string': 'another',
+            'unknown': 2000,
+        }))
+
+    cfg = MyConfig()
+
+    assert cfg.number == 200
+    assert cfg.string == 'another'
+
+
+def test_stores_on_update(tmp_directory):
+    cfg = MyConfig()
+
+    cfg.number = 500
+
+    content = yaml.safe_load(Path('myconfig.yaml').read_text())
+
+    assert content == {'number': 500, 'string': 'value'}
+
+
+def test_uses_default_if_missing(tmp_directory):
+    path = Path('myconfig.yaml')
+    path.write_text(yaml.dump({'number': 100}))
+
+    cfg = MyConfig()
+
+    assert cfg.number == 100
+    assert cfg.string == 'value'
+
+
+@pytest.mark.parametrize('content', ['not yaml', '[[]'])
+def test_uses_defaults_if_corrupted(tmp_directory, content):
+    path = Path('myconfig.yaml')
+    path.write_text(content)
+
+    cfg = MyConfig()
+    content = yaml.safe_load(Path('myconfig.yaml').read_text())
+
+    assert cfg.number == 42
+    assert cfg.string == 'value'
+    assert content == {'number': 42, 'string': 'value'}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,17 @@ class MyConfig(Config):
         return Path('myconfig.yaml')
 
 
+class AnotherConfig(Config):
+    uuid: str
+    another: str = 'default'
+
+    def path(self):
+        return Path('another.yaml')
+
+    def uuid_default(self):
+        return 'some-value'
+
+
 def test_stores_defaults(tmp_directory):
     MyConfig()
 
@@ -78,3 +89,23 @@ def test_uses_defaults_if_corrupted(tmp_directory, content):
     assert cfg.number == 42
     assert cfg.string == 'value'
     assert content == {'number': 42, 'string': 'value'}
+
+
+def test_config_with_factory(tmp_directory):
+    cfg = AnotherConfig()
+
+    assert cfg.uuid == 'some-value'
+    assert cfg.another == 'default'
+
+
+def test_factory_keeps_existing_values(tmp_directory):
+    path = Path('another.yaml')
+    values = {'uuid': 'my-uuid', 'another': 'some-value'}
+    path.write_text(yaml.dump(values))
+
+    cfg = AnotherConfig()
+    content = yaml.safe_load(Path('another.yaml').read_text())
+
+    assert cfg.uuid == 'my-uuid'
+    assert cfg.another == 'some-value'
+    assert content == values


### PR DESCRIPTION
I refactored the logic to store and retrieve the data from the config files. This is a pre-requisite to start working on the improved onboarding workflow where we have a "tutorial" to point to the user what do to next since we need to add a few extra flags to the config files to track the state.

The tests remain unchanged (I only modified a few and deleted some that are outdated)