### PR TITLE
add ploomber cloud nested suggestion for cli

### DIFF
--- a/src/ploomber_cli/cli.py
+++ b/src/ploomber_cli/cli.py
@@ -319,11 +319,30 @@ def cmd_router():
     else:
         suggestion = _suggest_command(cmd_name, cli.commands.keys())
 
+        # Set nested command keys based on command option
+        nested_cmds = {'cloud': cloud.commands.keys()}
+
+        # Evaluate nested command and provide suggested command if applicable
+        if cmd_name in nested_cmds:
+            nested_cmd_name = None if len(sys.argv) < 3 else sys.argv[2]
+            nested_suggestion = _suggest_command(nested_cmd_name,
+                                                 nested_cmds[cmd_name])
+        else:
+            nested_suggestion = None
+
         if suggestion:
             _exit_with_error_message(
                 "Try 'ploomber --help' for help.\n\n"
                 f"Error: {cmd_name!r} is not a valid command."
                 f" Did you mean {suggestion!r}?")
+        elif nested_suggestion:
+            cmds = f'{cmd_name} {nested_cmd_name}'
+            suggestion = f'{cmd_name} {nested_suggestion}'
+            suggested_help = f'ploomber {cmd_name} --help'
+
+            _exit_with_error_message(f"Try {suggested_help!r} for help.\n\n"
+                                     f"Error: {cmds!r} is not a valid command."
+                                     f" Did you mean {suggestion!r}?")
         else:
             cli()
 

--- a/tests/cli/test_suggest_command.py
+++ b/tests/cli/test_suggest_command.py
@@ -1,6 +1,7 @@
 import pytest
 
-from ploomber_cli.cli import _suggest_command
+from ploomber_cli.cli import _suggest_command, cmd_router
+import sys
 
 
 @pytest.mark.parametrize('name, expected', [
@@ -15,3 +16,31 @@ from ploomber_cli.cli import _suggest_command
 ])
 def test_suggest_command(name, expected):
     assert _suggest_command(name, ['do', 'make']) == expected
+
+
+@pytest.mark.parametrize('name, expected', [
+    ['gt-key', 'get-key'],
+    ['gt', None],
+])
+def test_nested_suggest_command(name, expected):
+    assert _suggest_command(
+        name, ['set-key', 'get-key', 'get-pipelines']) == expected
+
+
+@pytest.mark.parametrize('cmd, nested_cmd, suggestion', [
+    ['cloud', 'gt-key', 'get-key'],
+    ['cloud', 'gt', None],
+])
+def test_nested_suggestions(monkeypatch, capsys, cmd, nested_cmd, suggestion):
+    monkeypatch.setattr(sys, 'argv', ['ploomber', cmd, nested_cmd])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cmd_router()
+
+    captured = capsys.readouterr()
+
+    if suggestion:
+        assert f"Did you mean '{cmd} {suggestion}'?" in captured.err
+    else:
+        assert f"No such command '{nested_cmd}'" in captured.err
+    assert excinfo.value.code == 2


### PR DESCRIPTION
Previously, when a user input an incorrect nested command for `ploomber cloud`, ploomber cli didn't suggest a close match for the nested command. This PR enables nested command suggestion for the ploomber cloud command options (ie get-key, get-pipelines, etc)

2 files changed - 1 includes the updated cli functionality and added 2 new tests.

Issue for reference: https://github.com/ploomber/ploomber/issues/639