### PR TITLE
Adds terminal styling to Python inline examples (fixes #766)

### DIFF
--- a/doc/_static/js/custom.js
+++ b/doc/_static/js/custom.js
@@ -18,6 +18,9 @@ $(document).ready(function () {
     editor = document.getElementsByClassName("text-editor");
     addTerminalStyle(editor, "Text editor", (buttons = true));
 
+    python = document.getElementsByClassName("python-console");
+    addTerminalStyle(python, "Terminal (Python)", (buttons = true));
+
     // TODO: this should listen for click events in the whole terminal
     // window, not only in the content sub-window
     $("div.highlight").click(function () {

--- a/src/ploomber/clients/db.py
+++ b/src/ploomber/clients/db.py
@@ -51,9 +51,12 @@ class DBAPIClient(Client):
 
     Examples
     --------
-    >>> from ploomber.clients import DBAPIClient
-    >>> import sqlite3
-    >>> client = DBAPIClient(sqlite3.connect, dict(database='my.db'))
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.clients import DBAPIClient
+        >>> import sqlite3
+        >>> client = DBAPIClient(sqlite3.connect, dict(database='my.db'))
     """
     def __init__(self, connect_fn, connect_kwargs, split_source=None):
         super().__init__()
@@ -132,12 +135,15 @@ class SQLAlchemyClient(Client):
 
     Examples
     --------
-    >>> from ploomber.clients import SQLAlchemyClient
-    >>> client = SQLAlchemyClient('sqlite:///my_db.db')
-    >>> import sqlalchemy
-    >>> url = sqlalchemy.engine.url.URL.create(drivername='sqlite',
-    ...                                        database='my_db.db')
-    >>> client = SQLAlchemyClient(url)
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.clients import SQLAlchemyClient
+        >>> client = SQLAlchemyClient('sqlite:///my_db.db')
+        >>> import sqlalchemy
+        >>> url = sqlalchemy.engine.url.URL.create(drivername='sqlite',
+        ...                                        database='my_db.db')
+        >>> client = SQLAlchemyClient(url)
     """
     split_source_mapping = {'sqlite': ';'}
 

--- a/src/ploomber/cloud/__init__.py
+++ b/src/ploomber/cloud/__init__.py
@@ -6,8 +6,11 @@ def download_data(key):
 
     Examples
     --------
-    >>> from ploomber.cloud import download_data
-    >>> download_data('raw.csv') # doctest: +SKIP
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.cloud import download_data
+        >>> download_data('raw.csv') # doctest: +SKIP
     """
     # TODO: this should find the root directory and download relative to it
     # then return the absolute path

--- a/src/ploomber/cloud/io.py
+++ b/src/ploomber/cloud/io.py
@@ -61,9 +61,12 @@ class UploadJobGenerator:
 
     Examples
     --------
-    >>> from ploomber.cloud import io
-    >>> io.upload('v2.mov', 5 * 1024 * 1024,
-    ...     'ploomber-bucket', 'raw/v2.mov') # doctest: +SKIP
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.cloud import io
+        >>> io.upload('v2.mov', 5 * 1024 * 1024,
+        ...     'ploomber-bucket', 'raw/v2.mov') # doctest: +SKIP
 
     Notes
     -----

--- a/src/ploomber/dag/dag.py
+++ b/src/ploomber/dag/dag.py
@@ -181,25 +181,28 @@ class DAG(AbstractDAG):
 
     Python API:
 
-    >>> from pathlib import Path
-    >>> from ploomber import DAG
-    >>> from ploomber.tasks import ShellScript, PythonCallable
-    >>> from ploomber.products import File
-    >>> from ploomber.executors import Serial
-    >>> code = ("echo hi > {{product['first']}}; "
-    ...         "echo bye > {{product['second']}}")
-    >>> _ = Path('script.sh').write_text(code)
-    >>> dag = DAG(executor=Serial(build_in_subprocess=False))
-    >>> product = {'first': File('first.txt'), 'second': File('second.txt')}
-    >>> shell = ShellScript(Path('script.sh'), product, dag=dag, name='script')
-    >>> def my_task(upstream, product):
-    ...     first = Path(upstream['script']['first']).read_text()
-    ...     second = Path(upstream['script']['second']).read_text()
-    ...     Path(product).write_text(first + ' ' + second)
-    >>> callable = PythonCallable(my_task, File('final.txt'), dag=dag)
-    >>> shell >> callable
-    PythonCallable: my_task -> File('final.txt')
-    >>> _ = dag.build()
+    .. code-block:: python
+        :class: python-console
+
+        >>> from pathlib import Path
+        >>> from ploomber import DAG
+        >>> from ploomber.tasks import ShellScript, PythonCallable
+        >>> from ploomber.products import File
+        >>> from ploomber.executors import Serial
+        >>> code = ("echo hi > {{product['first']}}; "
+        ...         "echo bye > {{product['second']}}")
+        >>> _ = Path('script.sh').write_text(code)
+        >>> dag = DAG(executor=Serial(build_in_subprocess=False))
+        >>> product = {'first': File('first.txt'), 'second': File('second.txt')}
+        >>> shell = ShellScript(Path('script.sh'), product, dag=dag, name='script')
+        >>> def my_task(upstream, product):
+        ...     first = Path(upstream['script']['first']).read_text()
+        ...     second = Path(upstream['script']['second']).read_text()
+        ...     Path(product).write_text(first + ' ' + second)
+        >>> callable = PythonCallable(my_task, File('final.txt'), dag=dag)
+        >>> shell >> callable
+        PythonCallable: my_task -> File('final.txt')
+        >>> _ = dag.build()
 
     """
     def __init__(self, name=None, clients=None, executor='serial'):

--- a/src/ploomber/dag/dagconfigurator.py
+++ b/src/ploomber/dag/dagconfigurator.py
@@ -34,12 +34,15 @@ class DAGConfigurator:
 
     Examples
     --------
-    >>> from ploomber import DAGConfigurator
-    >>> configurator = DAGConfigurator()
-    >>> configurator.params.outdated_by_code = True
-    >>> configurator.params.cache_rendered_status = False
-    >>> configurator.params.hot_reload = True
-    >>> dag = configurator.create()
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber import DAGConfigurator
+        >>> configurator = DAGConfigurator()
+        >>> configurator.params.outdated_by_code = True
+        >>> configurator.params.cache_rendered_status = False
+        >>> configurator.params.hot_reload = True
+        >>> dag = configurator.create()
     """
     def __init__(self, d=None):
         if d:

--- a/src/ploomber/dag/onlinedag.py
+++ b/src/ploomber/dag/onlinedag.py
@@ -143,9 +143,12 @@ class OnlineModel(OnlineDAG):
 
     Examples
     --------
-    >>> import my_module # doctest: +SKIP
-    >>> model = OnlineModel(my_module) # doctest: +SKIP
-    >>> model.predict(x=some_input) # doctest: +SKIP
+    .. code-block:: python
+        :class: python-console
+
+        >>> import my_module # doctest: +SKIP
+        >>> model = OnlineModel(my_module) # doctest: +SKIP
+        >>> model.predict(x=some_input) # doctest: +SKIP
     """
     def __init__(self, module):
         self._module = module

--- a/src/ploomber/env/env.py
+++ b/src/ploomber/env/env.py
@@ -34,12 +34,15 @@ class Env:
 
     Examples
     --------
-    >>> from ploomber import Env
-    >>> env = Env({'db': {'uri': 'my_uri'}, 'path': {'raw': '/path/to/raw'}})
-    >>> env.db.uri
-    'my_uri'
-    >>> env.path.raw
-    PosixPath('/path/to/raw')
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber import Env
+        >>> env = Env({'db': {'uri': 'my_uri'}, 'path': {'raw': '/path/to/raw'}})
+        >>> env.db.uri
+        'my_uri'
+        >>> env.path.raw
+        PosixPath('/path/to/raw')
 
     Notes
     -----

--- a/src/ploomber/executors/parallel.py
+++ b/src/ploomber/executors/parallel.py
@@ -73,10 +73,13 @@ class Parallel(Executor):
 
     Python API:
 
-    >>> from ploomber import DAG
-    >>> from ploomber.executors import Parallel
-    >>> dag = DAG(executor='parallel') # use with default values
-    >>> dag = DAG(executor=Parallel(processes=2)) # customize
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber import DAG
+        >>> from ploomber.executors import Parallel
+        >>> dag = DAG(executor='parallel') # use with default values
+        >>> dag = DAG(executor=Parallel(processes=2)) # customize
 
 
     Notes

--- a/src/ploomber/io/_commander.py
+++ b/src/ploomber/io/_commander.py
@@ -184,7 +184,10 @@ class Commander:
 
         Examples
         --------
-        >>> cmdr.rm('file', 'directory') # doctest: +SKIP
+        .. code-block:: python
+            :class: python-console
+
+            >>> cmdr.rm('file', 'directory') # doctest: +SKIP
         """
         for f in args:
             _delete(f)
@@ -194,7 +197,10 @@ class Commander:
 
         Examples
         --------
-        >>> cmdr.rm_on_exit('some_temporary_file') # doctest: +SKIP
+        .. code-block:: python
+            :class: python-console
+
+            >>> cmdr.rm_on_exit('some_temporary_file') # doctest: +SKIP
         """
         self._to_delete.append(Path(path).resolve())
 
@@ -211,9 +217,12 @@ class Commander:
 
         Examples
         --------
-        >>> # copies template in {templates-path}/directory/template.yaml
-        >>> # to {workspace}/template.yaml
-        >>> cmdr.copy_template('directory/template.yaml') # doctest: +SKIP
+        .. code-block:: python
+            :class: python-console
+
+            >>> # copies template in {templates-path}/directory/template.yaml
+            >>> # to {workspace}/template.yaml
+            >>> cmdr.copy_template('directory/template.yaml') # doctest: +SKIP
         """
         dst = Path(self.workspace, PurePosixPath(path).name)
 
@@ -244,8 +253,11 @@ class Commander:
 
         Examples
         --------
-        >>> # copies dir/file to {workspace}/file
-        >>> cmdr.cp('dir/file') # doctest: +SKIP
+        .. code-block:: python
+            :class: python-console
+
+            >>> # copies dir/file to {workspace}/file
+            >>> cmdr.cp('dir/file') # doctest: +SKIP
         """
         path = Path(src)
 
@@ -277,7 +289,10 @@ class Commander:
 
         Examples
         --------
-        >>> cmdr.append_inline('*.csv', '.gitignore') # doctest: +SKIP
+        .. code-block:: python
+            :class: python-console
+
+            >>> cmdr.append_inline('*.csv', '.gitignore') # doctest: +SKIP
         """
         if not Path(dst).exists():
             Path(dst).touch()

--- a/src/ploomber/io/_commander_tester.py
+++ b/src/ploomber/io/_commander_tester.py
@@ -21,16 +21,19 @@ class CommanderTester:
 
     Examples
     --------
-    >>> from unittest.mock import Mock
-    >>> from ploomber.io import _commander
-    >>> tester = CommanderTester(run=[('python', 'script.py')],
-    ...                       return_value={('python', '--version'): b'3.10'})
-    >>> subprocess_mock = Mock()
-    >>> # we need to mock check_all and check_output since Commander uses both
-    >>> subprocess_mock.check_call.side_effect = tester
-    >>> subprocess_mock.check_output.side_effect = tester
-    >>> monkeypatch.setattr(_commander, 'subprocess',
-    ...     subprocess_mock) # doctest: +SKIP
+    .. code-block:: python
+        :class: python-console
+
+        >>> from unittest.mock import Mock
+        >>> from ploomber.io import _commander
+        >>> tester = CommanderTester(run=[('python', 'script.py')],
+        ...                       return_value={('python', '--version'): b'3.10'})
+        >>> subprocess_mock = Mock()
+        >>> # we need to mock check_all and check_output since Commander uses both
+        >>> subprocess_mock.check_call.side_effect = tester
+        >>> subprocess_mock.check_output.side_effect = tester
+        >>> monkeypatch.setattr(_commander, 'subprocess',
+        ...     subprocess_mock) # doctest: +SKIP
     """
     def __init__(self, run=None, return_value=None):
         self._run = run or []

--- a/src/ploomber/jupyter/manager.py
+++ b/src/ploomber/jupyter/manager.py
@@ -3,11 +3,15 @@ Module for the jupyter extension
 
 
 For debugging:
->>> from ploomber.jupyter.dag import JupyterDAGManager
->>> from ploomber.jupyter.manager import derive_class
->>> from jupytext.contentsmanager import TextFileContentsManager
->>> PloomberContentsManager = derive_class(TextFileContentsManager)
->>> cm = PloomberContentsManager()
+
+.. code-block:: python
+    :class: python-console
+
+    >>> from ploomber.jupyter.dag import JupyterDAGManager
+    >>> from ploomber.jupyter.manager import derive_class
+    >>> from jupytext.contentsmanager import TextFileContentsManager
+    >>> PloomberContentsManager = derive_class(TextFileContentsManager)
+    >>> cm = PloomberContentsManager()
 """
 import sys
 import datetime

--- a/src/ploomber/placeholders/sourceloader.py
+++ b/src/ploomber/placeholders/sourceloader.py
@@ -36,10 +36,13 @@ class SourceLoader:
 
     Examples
     --------
-    >>> from ploomber import SourceLoader
-    >>> loader = SourceLoader('path/to/templates/')
-    >>> loader['load_customers.sql'] # doctest: +SKIP
-    >>> loader.get_template('load_customers.sql') # doctest: +SKIP
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber import SourceLoader
+        >>> loader = SourceLoader('path/to/templates/')
+        >>> loader['load_customers.sql'] # doctest: +SKIP
+        >>> loader.get_template('load_customers.sql') # doctest: +SKIP
     """
     def __init__(self, path=None, module=None):
 

--- a/src/ploomber/products/sql.py
+++ b/src/ploomber/products/sql.py
@@ -141,10 +141,13 @@ class SQLiteRelation(SQLProductMixin, SQLiteBackedProductMixin, Product):
 
     Examples
     --------
-    >>> from ploomber.products import SQLiteRelation
-    >>> relation = SQLiteRelation(('schema', 'some_table', 'table'))
-    >>> str(relation) # returns qualified name
-    'schema.some_table'
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.products import SQLiteRelation
+        >>> relation = SQLiteRelation(('schema', 'some_table', 'table'))
+        >>> str(relation) # returns qualified name
+        'schema.some_table'
     """
     def __init__(self, identifier, client=None):
         super().__init__(identifier)
@@ -214,10 +217,13 @@ class PostgresRelation(SQLProductMixin, ProductWithClientMixin, Product):
 
     Examples
     --------
-    >>> from ploomber.products import PostgresRelation
-    >>> relation = PostgresRelation(('schema', 'some_table', 'table'))
-    >>> str(relation) # returns qualified name
-    'schema.some_table'
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.products import PostgresRelation
+        >>> relation = PostgresRelation(('schema', 'some_table', 'table'))
+        >>> str(relation) # returns qualified name
+        'schema.some_table'
     """
 
     # FIXME: identifier has schema as optional but that introduces ambiguity

--- a/src/ploomber/sources/interact.py
+++ b/src/ploomber/sources/interact.py
@@ -74,10 +74,13 @@ class CallableInteractiveDeveloper:
 
     Examples
     --------
-    >>> with CallableInteractiveDeveloper(fn, # doctest: +SKIP
-    ...     {'param': 1}) as path_to_nb:
-    ...     # do stuff with the notebook file
-    ...     pass
+    .. code-block:: python
+        :class: python-console
+
+        >>> with CallableInteractiveDeveloper(fn, # doctest: +SKIP
+        ...     {'param': 1}) as path_to_nb:
+        ...     # do stuff with the notebook file
+        ...     pass
     """
     def __init__(self, fn, params):
         self.fn = fn

--- a/src/ploomber/table.py
+++ b/src/ploomber/table.py
@@ -24,8 +24,11 @@ class Row:
 
     Examples
     --------
-    >>> from ploomber.table import Row
-    >>> row = Row({'a': 'some value', 'b': 'another value'})
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.table import Row
+        >>> row = Row({'a': 'some value', 'b': 'another value'})
     """
     def __init__(self, mapping):
         if not isinstance(mapping, Mapping):

--- a/src/ploomber/tasks/notebook.py
+++ b/src/ploomber/tasks/notebook.py
@@ -514,37 +514,43 @@ class NotebookRunner(NotebookMixin, Task):
 
     Python API:
 
-    >>> from pathlib import Path
-    >>> from ploomber import DAG
-    >>> from ploomber.tasks import NotebookRunner
-    >>> from ploomber.products import File
-    >>> dag = DAG()
-    >>> NotebookRunner(Path('nb.ipynb'), File('report.html'), dag=dag)
-    NotebookRunner: nb -> File('report.html')
-    >>> dag.build() # doctest: +SKIP
+    .. code-block:: python
+        :class: python-console
+
+        >>> from pathlib import Path
+        >>> from ploomber import DAG
+        >>> from ploomber.tasks import NotebookRunner
+        >>> from ploomber.products import File
+        >>> dag = DAG()
+        >>> NotebookRunner(Path('nb.ipynb'), File('report.html'), dag=dag)
+        NotebookRunner: nb -> File('report.html')
+        >>> dag.build() # doctest: +SKIP
 
     Python API (customize output notebook):
 
-    >>> from pathlib import Path
-    >>> from ploomber import DAG
-    >>> from ploomber.tasks import NotebookRunner
-    >>> from ploomber.products import File
-    >>> dag = DAG()
-    >>> # do not include input code (only cell's output)
-    >>> NotebookRunner(Path('nb.ipynb'), File('out-1.html'), dag=dag,
-    ...                nbconvert_export_kwargs={'exclude_input': True},
-    ...                name='one')
-    NotebookRunner: one -> File('out-1.html')
-    >>> # Selectively remove cells with the tag "remove"
-    >>> config = {'TagRemovePreprocessor': {'remove_cell_tags': ('remove',)},
-    ...        'HTMLExporter':
-    ...         {'preprocessors':
-    ...    ['nbconvert.preprocessors.TagRemovePreprocessor']}}
-    >>> NotebookRunner(Path('nb.ipynb'), File('out-2.html'), dag=dag,
-    ...                nbconvert_export_kwargs={'config': config},
-    ...                name='another')
-    NotebookRunner: another -> File('out-2.html')
-    >>> dag.build() # doctest: +SKIP
+    .. code-block:: python
+        :class: python-console
+
+        >>> from pathlib import Path
+        >>> from ploomber import DAG
+        >>> from ploomber.tasks import NotebookRunner
+        >>> from ploomber.products import File
+        >>> dag = DAG()
+        >>> # do not include input code (only cell's output)
+        >>> NotebookRunner(Path('nb.ipynb'), File('out-1.html'), dag=dag,
+        ...                nbconvert_export_kwargs={'exclude_input': True},
+        ...                name='one')
+        NotebookRunner: one -> File('out-1.html')
+        >>> # Selectively remove cells with the tag "remove"
+        >>> config = {'TagRemovePreprocessor': {'remove_cell_tags': ('remove',)},
+        ...        'HTMLExporter':
+        ...         {'preprocessors':
+        ...    ['nbconvert.preprocessors.TagRemovePreprocessor']}}
+        >>> NotebookRunner(Path('nb.ipynb'), File('out-2.html'), dag=dag,
+        ...                nbconvert_export_kwargs={'config': config},
+        ...                name='another')
+        NotebookRunner: another -> File('out-2.html')
+        >>> dag.build() # doctest: +SKIP
 
     Notes
     -----
@@ -698,14 +704,17 @@ class ScriptRunner(NotebookMixin, Task):
 
     Python API:
 
-    >>> from pathlib import Path
-    >>> from ploomber import DAG
-    >>> from ploomber.tasks import ScriptRunner
-    >>> from ploomber.products import File
-    >>> dag = DAG()
-    >>> product = {'data': File('data.csv'), 'another': File('another.csv')}
-    >>> _ = ScriptRunner(Path('script.py'), product, dag=dag)
-    >>> _ = dag.build()
+    .. code-block:: python
+        :class: python-console
+
+        >>> from pathlib import Path
+        >>> from ploomber import DAG
+        >>> from ploomber.tasks import ScriptRunner
+        >>> from ploomber.products import File
+        >>> dag = DAG()
+        >>> product = {'data': File('data.csv'), 'another': File('another.csv')}
+        >>> _ = ScriptRunner(Path('script.py'), product, dag=dag)
+        >>> _ = dag.build()
     """
     @requires(['jupyter', 'jupytext'], 'ScriptRunner')
     def __init__(self,

--- a/src/ploomber/tasks/sql.py
+++ b/src/ploomber/tasks/sql.py
@@ -144,27 +144,30 @@ class SQLDump(io.FileLoaderMixin, ClientMixin, Task):
 
     Python API:
 
-    >>> import sqlite3
-    >>> import pandas as pd
-    >>> from ploomber import DAG
-    >>> from ploomber.products import File
-    >>> from ploomber.tasks import SQLDump
-    >>> from ploomber.clients import DBAPIClient
-    >>> con_raw = sqlite3.connect(database='my_db.db')
-    >>> df = pd.DataFrame({'a': range(100), 'b': range(100)})
-    >>> _ = df.to_sql('numbers', con_raw, index=False)
-    >>> con_raw.close()
-    >>> dag = DAG()
-    >>> client = DBAPIClient(sqlite3.connect, dict(database='my_db.db'))
-    >>> _ = SQLDump('SELECT * FROM numbers', File('data.parquet'),
-    ...             dag=dag, name='dump', client=client, chunksize=None)
-    >>> _ = dag.build()
-    >>> df = pd.read_parquet('data.parquet')
-    >>> df.head(3)
-       a  b
-    0  0  0
-    1  1  1
-    2  2  2
+    .. code-block:: python
+        :class: python-console
+
+        >>> import sqlite3
+        >>> import pandas as pd
+        >>> from ploomber import DAG
+        >>> from ploomber.products import File
+        >>> from ploomber.tasks import SQLDump
+        >>> from ploomber.clients import DBAPIClient
+        >>> con_raw = sqlite3.connect(database='my_db.db')
+        >>> df = pd.DataFrame({'a': range(100), 'b': range(100)})
+        >>> _ = df.to_sql('numbers', con_raw, index=False)
+        >>> con_raw.close()
+        >>> dag = DAG()
+        >>> client = DBAPIClient(sqlite3.connect, dict(database='my_db.db'))
+        >>> _ = SQLDump('SELECT * FROM numbers', File('data.parquet'),
+        ...             dag=dag, name='dump', client=client, chunksize=None)
+        >>> _ = dag.build()
+        >>> df = pd.read_parquet('data.parquet')
+        >>> df.head(3)
+           a  b
+        0  0  0
+        1  1  1
+        2  2  2
 
     Notes
     -----

--- a/src/ploomber/tasks/tasks.py
+++ b/src/ploomber/tasks/tasks.py
@@ -134,35 +134,40 @@ class PythonCallable(Task):
 
     Python API:
 
-    >>> from pathlib import Path
-    >>> from ploomber import DAG
-    >>> from ploomber.tasks import PythonCallable
-    >>> from ploomber.products import File
-    >>> from ploomber.executors import Serial
-    >>> dag = DAG(executor=Serial(build_in_subprocess=False))
-    >>> def my_function(product):
-    ...     # create data.csv
-    ...     Path(product).touch()
-    >>> PythonCallable(my_function, File('data.csv'), dag=dag)
-    PythonCallable: my_function -> File('data.csv')
-    >>> summary = dag.build()
+    .. code-block:: python
+        :class: python-console
+
+        >>> from pathlib import Path
+        >>> from ploomber import DAG
+        >>> from ploomber.tasks import PythonCallable
+        >>> from ploomber.products import File
+        >>> from ploomber.executors import Serial
+        >>> dag = DAG(executor=Serial(build_in_subprocess=False))
+        >>> def my_function(product):
+        ...     # create data.csv
+        ...     Path(product).touch()
+        >>> PythonCallable(my_function, File('data.csv'), dag=dag)
+        PythonCallable: my_function -> File('data.csv')
+        >>> summary = dag.build()
 
     Python API (multiple products):
 
+    .. code-block:: python
+        :class: python-console
 
-    >>> from pathlib import Path
-    >>> from ploomber import DAG
-    >>> from ploomber.tasks import PythonCallable
-    >>> from ploomber.products import File
-    >>> from ploomber.executors import Serial
-    >>> dag = DAG(executor=Serial(build_in_subprocess=False))
-    >>> def my_function(product):
-    ...     Path(product['first']).touch()
-    ...     Path(product['second']).touch()
-    >>> product = {'first': File('first.csv'),
-    ...            'second': File('second.csv')}
-    >>> task = PythonCallable(my_function, product, dag=dag)
-    >>> summary = dag.build()
+        >>> from pathlib import Path
+        >>> from ploomber import DAG
+        >>> from ploomber.tasks import PythonCallable
+        >>> from ploomber.products import File
+        >>> from ploomber.executors import Serial
+        >>> dag = DAG(executor=Serial(build_in_subprocess=False))
+        >>> def my_function(product):
+        ...     Path(product['first']).touch()
+        ...     Path(product['second']).touch()
+        >>> product = {'first': File('first.csv'),
+        ...            'second': File('second.csv')}
+        >>> task = PythonCallable(my_function, product, dag=dag)
+        >>> summary = dag.build()
 
 
     Notes
@@ -403,16 +408,19 @@ class ShellScript(ClientMixin, Task):
 
     Python API:
 
-    >>> from pathlib import Path
-    >>> from ploomber import DAG
-    >>> from ploomber.tasks import ShellScript
-    >>> from ploomber.products import File
-    >>> code = "touch {{product['first']}}; touch {{product['second']}}"
-    >>> _ = Path('script.sh').write_text(code)
-    >>> dag = DAG()
-    >>> product = {'first': File('first.txt'), 'second': File('second.txt')}
-    >>> _ = ShellScript(Path('script.sh'), product, dag=dag)
-    >>> summary = dag.build()
+    .. code-block:: python
+        :class: python-console
+
+        >>> from pathlib import Path
+        >>> from ploomber import DAG
+        >>> from ploomber.tasks import ShellScript
+        >>> from ploomber.products import File
+        >>> code = "touch {{product['first']}}; touch {{product['second']}}"
+        >>> _ = Path('script.sh').write_text(code)
+        >>> dag = DAG()
+        >>> product = {'first': File('first.txt'), 'second': File('second.txt')}
+        >>> _ = ShellScript(Path('script.sh'), product, dag=dag)
+        >>> summary = dag.build()
 
     """
     def __init__(self,

--- a/src/ploomber/util/param_grid.py
+++ b/src/ploomber/util/param_grid.py
@@ -8,18 +8,21 @@ class Interval:
     """Generate intervals from lower to upper of size delta, last interval
     will be smaller if needed
 
-    >>> from ploomber.util import Interval
-    >>> from datetime import date
-    >>> from dateutil.relativedelta import relativedelta
-    >>> interval = Interval(date(year=2020, month=1, day=1),
-    ...                     date(year=2022, month=6, day=1),
-    ...                     relativedelta(years=1)).expand()
-    >>> interval[0]
-    (datetime.date(2020, 1, 1), datetime.date(2021, 1, 1))
-    >>> interval[1]
-    (datetime.date(2021, 1, 1), datetime.date(2022, 1, 1))
-    >>> interval[2]
-    (datetime.date(2022, 1, 1), datetime.date(2022, 6, 1))
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.util import Interval
+        >>> from datetime import date
+        >>> from dateutil.relativedelta import relativedelta
+        >>> interval = Interval(date(year=2020, month=1, day=1),
+        ...                     date(year=2022, month=6, day=1),
+        ...                     relativedelta(years=1)).expand()
+        >>> interval[0]
+        (datetime.date(2020, 1, 1), datetime.date(2021, 1, 1))
+        >>> interval[1]
+        (datetime.date(2021, 1, 1), datetime.date(2022, 1, 1))
+        >>> interval[2]
+        (datetime.date(2022, 1, 1), datetime.date(2022, 6, 1))
     """
     def __init__(self, lower, upper, delta):
         if lower >= upper:
@@ -65,19 +68,22 @@ class ParamGrid:
 
     Examples
     --------
-    >>> pg = ParamGrid({'a': [1, 2, 3], 'b': [2, 4, 6]})
-    >>> list(pg.zip())
-    [{'a': 1, 'b': 2}, {'a': 2, 'b': 4}, {'a': 3, 'b': 6}]
+    .. code-block:: python
+        :class: python-console
 
-    >>> list(pg.product())  # doctest: +NORMALIZE_WHITESPACE
-    [{'a': 1, 'b': 2}, {'a': 1, 'b': 4}, {'a': 1, 'b': 6}, {'a': 2, 'b': 2},
-    {'a': 2, 'b': 4}, {'a': 2, 'b': 6}, {'a': 3, 'b': 2}, {'a': 3, 'b': 4},
-    {'a': 3, 'b': 6}]
+        >>> pg = ParamGrid({'a': [1, 2, 3], 'b': [2, 4, 6]})
+        >>> list(pg.zip())
+        [{'a': 1, 'b': 2}, {'a': 2, 'b': 4}, {'a': 3, 'b': 6}]
 
-    >>> pg = ParamGrid({'a': Interval(0, 10, 2), 'b': [2, 4, 6, 8, 10]})
-    >>> list(pg.zip())  # doctest: +NORMALIZE_WHITESPACE
-    [{'a': (0, 2), 'b': 2}, {'a': (2, 4), 'b': 4}, {'a': (4, 6), 'b': 6},
-    {'a': (6, 8), 'b': 8}, {'a': (8, 10), 'b': 10}]
+        >>> list(pg.product())  # doctest: +NORMALIZE_WHITESPACE
+        [{'a': 1, 'b': 2}, {'a': 1, 'b': 4}, {'a': 1, 'b': 6}, {'a': 2, 'b': 2},
+        {'a': 2, 'b': 4}, {'a': 2, 'b': 6}, {'a': 3, 'b': 2}, {'a': 3, 'b': 4},
+        {'a': 3, 'b': 6}]
+
+        >>> pg = ParamGrid({'a': Interval(0, 10, 2), 'b': [2, 4, 6, 8, 10]})
+        >>> list(pg.zip())  # doctest: +NORMALIZE_WHITESPACE
+        [{'a': (0, 2), 'b': 2}, {'a': (2, 4), 'b': 4}, {'a': (4, 6), 'b': 6},
+        {'a': (6, 8), 'b': 8}, {'a': (8, 10), 'b': 10}]
 
     Notes
     -----

--- a/src/ploomber/validators/validators.py
+++ b/src/ploomber/validators/validators.py
@@ -10,12 +10,15 @@ class Assert:
 
     Examples
     --------
-    >>> from ploomber.validators import Assert
-    >>> assert_ = Assert()
-    >>> assert_(True, 'This wont be displayed')
-    >>> assert_(False, 'This will be displayed')
-    >>> assert_(False, 'This will also be displayed')
-    >>> assert_.check() # doctest: +SKIP
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.validators import Assert
+        >>> assert_ = Assert()
+        >>> assert_(True, 'This wont be displayed')
+        >>> assert_(False, 'This will be displayed')
+        >>> assert_(False, 'This will also be displayed')
+        >>> assert_.check() # doctest: +SKIP
     """
     def __init__(self):
         self.messages_error = []
@@ -184,18 +187,21 @@ def data_frame_validator(df, validators):
 
     Examples
     --------
-    >>> from ploomber.validators import data_frame_validator
-    >>> from ploomber.validators import validate_schema, validate_values
-    >>> import pandas as pd
-    >>> import numpy as np
-    >>> df = pd.DataFrame({'x': np.random.rand(3), 'y': np.random.rand(3),
-    ...                    'z': [0, 1, 2], 'i': ['a', 'b', 'c']})
-    >>> data_frame_validator(df,
-    ...                     [validate_schema(schema={'x': 'int', 'z': 'int'}),
-    ...                      validate_values(values={'z': ('range', (0, 1)),
-    ...                                              'i': ('unique', {'a'}),
-    ...                                              'j': ('unique', {'b'})}
-    ...                                      )]) # doctest: +SKIP
+    .. code-block:: python
+        :class: python-console
+
+        >>> from ploomber.validators import data_frame_validator
+        >>> from ploomber.validators import validate_schema, validate_values
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> df = pd.DataFrame({'x': np.random.rand(3), 'y': np.random.rand(3),
+        ...                    'z': [0, 1, 2], 'i': ['a', 'b', 'c']})
+        >>> data_frame_validator(df,
+        ...                     [validate_schema(schema={'x': 'int', 'z': 'int'}),
+        ...                      validate_values(values={'z': ('range', (0, 1)),
+        ...                                              'i': ('unique', {'a'}),
+        ...                                              'j': ('unique', {'b'})}
+        ...                                      )]) # doctest: +SKIP
     """
     assert_ = Assert()
 


### PR DESCRIPTION
## Changes:

- Python inline examples in the source code have been moved into code-blocks
- Terminal style has been added to these code-blocks by their `python-console` class name

## Decisions:

- I decided to move the Python inline examples into code-blocks, because without it they only get the default code-block css classes after doc gen, which makes it difficult to select them and apply the terminal style. Without this I either have to apply the styling to all default code-blocks or select them by their unique structure/content (like, looking for child elements with the content of `>>> `).