### PR TITLE
Improved error message

### DIFF
--- a/src/ploomber/util/util.py
+++ b/src/ploomber/util/util.py
@@ -243,18 +243,18 @@ def signature_check(fn, params, task_name):
         msg = '. '.join(errors)
         # not all functions have __name__ (e.g. partials)
         fn_name = getattr(fn, '__name__', fn)
-        ele = missing.pop()
-        if(dl.get_close_matches(
-            ele, ['product'], cutoff=0.1, n=1
-        ) == ['product']):
-            raise TaskRenderError(
-                'You are passing {}. Do you mean {}?'.format(ele, "product")
-            )
-        else:
-            raise TaskRenderError(
-                'Error rendering task "{}" initialized with '
-                    'function "{}". {}'.format(
-                        task_name, fn_name, msg))
+        for e in missing:
+            if(dl.get_close_matches(
+                e, ['product'], cutoff=0.1, n=1
+            ) == ['product']):
+                raise TaskRenderError(
+                    'You are passing {}. Do you mean {}?'.format(e, "product")
+                )
+            else:
+                raise TaskRenderError(
+                    'Error rendering task "{}" initialized with '
+                        'function "{}". {}'.format(
+                            task_name, fn_name, msg))
 
     return True
 

--- a/src/ploomber/util/util.py
+++ b/src/ploomber/util/util.py
@@ -245,7 +245,7 @@ def signature_check(fn, params, task_name):
         fn_name = getattr(fn, "__name__", fn)
         for e in missing:
             close_match = dl.get_close_matches(e, ["product"], cutoff=0.1, n=1)
-            if  close_match == ["product"]:
+            if close_match == ["product"]:
                 raise TaskRenderError(
                     "You are passing {}. Do you mean {}?".format(e, "product")
                 )

--- a/src/ploomber/util/util.py
+++ b/src/ploomber/util/util.py
@@ -244,8 +244,8 @@ def signature_check(fn, params, task_name):
         # not all functions have __name__ (e.g. partials)
         fn_name = getattr(fn, "__name__", fn)
         for e in missing:
-            if dl.get_close_matches(e, ["product"], cutoff=0.1, n=1
-            ) == ["product"]:
+            if dl.get_close_matches(e, ["product"],
+             cutoff=0.1, n=1) == ["product"]:
                 raise TaskRenderError(
                     "You are passing {}. Do you mean {}?".format(e, "product")
                 )

--- a/src/ploomber/util/util.py
+++ b/src/ploomber/util/util.py
@@ -244,7 +244,8 @@ def signature_check(fn, params, task_name):
         # not all functions have __name__ (e.g. partials)
         fn_name = getattr(fn, "__name__", fn)
         for e in missing:
-            if dl.get_close_matches(e, ["product"], cutoff=0.1, n=1) == ["product"]:
+            if dl.get_close_matches(e, ["product"], cutoff=0.1, n=1
+            ) == ["product"]:
                 raise TaskRenderError(
                     "You are passing {}. Do you mean {}?".format(e, "product")
                 )

--- a/src/ploomber/util/util.py
+++ b/src/ploomber/util/util.py
@@ -4,6 +4,7 @@ import warnings
 from pathlib import Path, WindowsPath
 import importlib
 from functools import wraps
+import difflib as dl
 import base64
 import shutil
 import inspect
@@ -242,9 +243,18 @@ def signature_check(fn, params, task_name):
         msg = '. '.join(errors)
         # not all functions have __name__ (e.g. partials)
         fn_name = getattr(fn, '__name__', fn)
-        raise TaskRenderError('Error rendering task "{}" initialized with '
-                              'function "{}". {}'.format(
-                                  task_name, fn_name, msg))
+        ele = missing.pop()
+        if(dl.get_close_matches(
+            ele, ['product'], cutoff=0.1, n=1
+        ) == ['product']):
+            raise TaskRenderError(
+                'You are passing {}. Do you mean {}?'.format(ele, "product")
+            )
+        else:
+            raise TaskRenderError(
+                'Error rendering task "{}" initialized with '
+                    'function "{}". {}'.format(
+                        task_name, fn_name, msg))
 
     return True
 

--- a/src/ploomber/util/util.py
+++ b/src/ploomber/util/util.py
@@ -244,8 +244,8 @@ def signature_check(fn, params, task_name):
         # not all functions have __name__ (e.g. partials)
         fn_name = getattr(fn, "__name__", fn)
         for e in missing:
-            if dl.get_close_matches(e, ["product"],
-             cutoff=0.1, n=1) == ["product"]:
+            close_match = dl.get_close_matches(e, ["product"], cutoff=0.1, n=1)
+            if  close_match == ["product"]:
                 raise TaskRenderError(
                     "You are passing {}. Do you mean {}?".format(e, "product")
                 )

--- a/src/ploomber/util/util.py
+++ b/src/ploomber/util/util.py
@@ -251,10 +251,9 @@ def signature_check(fn, params, task_name):
                     'You are passing {}. Do you mean {}?'.format(e, "product")
                 )
             else:
-                raise TaskRenderError(
-                    'Error rendering task "{}" initialized with '
-                        'function "{}". {}'.format(
-                            task_name, fn_name, msg))
+                raise TaskRenderError('Error rendering task "{}" initialized with '
+                              'function "{}". {}'.format(
+                                  task_name, fn_name, msg))
 
     return True
 

--- a/src/ploomber/util/util.py
+++ b/src/ploomber/util/util.py
@@ -240,20 +240,19 @@ def signature_check(fn, params, task_name):
         errors.append(f'Pass {missing_except_upstream} in "params"')
 
     if extra or missing:
-        msg = '. '.join(errors)
+        msg = ". ".join(errors)
         # not all functions have __name__ (e.g. partials)
-        fn_name = getattr(fn, '__name__', fn)
+        fn_name = getattr(fn, "__name__", fn)
         for e in missing:
-            if(dl.get_close_matches(
-                e, ['product'], cutoff=0.1, n=1
-            ) == ['product']):
+            if dl.get_close_matches(e, ["product"], cutoff=0.1, n=1) == ["product"]:
                 raise TaskRenderError(
-                    'You are passing {}. Do you mean {}?'.format(e, "product")
+                    "You are passing {}. Do you mean {}?".format(e, "product")
                 )
             else:
-                raise TaskRenderError('Error rendering task "{}" initialized with '
-                              'function "{}". {}'.format(
-                                  task_name, fn_name, msg))
+                raise TaskRenderError(
+                    'Error rendering task "{}" initialized with '
+                    'function "{}". {}'.format(task_name, fn_name, msg)
+                )
 
     return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ import os
 import pytest
 from pathlib import Path
 import tempfile
-import test_pkg
 from ploomber.clients import SQLAlchemyClient
 from ploomber import Env
 import pandas as pd
@@ -81,25 +80,6 @@ def path_to_tests():
 @pytest.fixture()
 def path_to_test_pkg():
     return str(Path(importlib.util.find_spec('test_pkg').origin).parent)
-
-
-@pytest.fixture
-def backup_test_pkg():
-    old = os.getcwd()
-    backup = tempfile.mkdtemp()
-    root = Path(test_pkg.__file__).parents[2]
-
-    # sanity check, in case we change the structure
-    assert root.name == 'test_pkg'
-
-    shutil.copytree(str(root), str(Path(backup, 'test_pkg')))
-
-    yield str(Path(importlib.util.find_spec('test_pkg').origin).parent)
-    os.chdir(old)
-
-    shutil.rmtree(str(root))
-    shutil.copytree(str(Path(backup, 'test_pkg')), str(root))
-    shutil.rmtree(backup)
 
 
 @fixture_backup('spec-with-functions')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ import os
 import pytest
 from pathlib import Path
 import tempfile
+import test_pkg
 from ploomber.clients import SQLAlchemyClient
 from ploomber import Env
 import pandas as pd
@@ -80,6 +81,25 @@ def path_to_tests():
 @pytest.fixture()
 def path_to_test_pkg():
     return str(Path(importlib.util.find_spec('test_pkg').origin).parent)
+
+
+@pytest.fixture
+def backup_test_pkg():
+    old = os.getcwd()
+    backup = tempfile.mkdtemp()
+    root = Path(test_pkg.__file__).parents[2]
+
+    # sanity check, in case we change the structure
+    assert root.name == 'test_pkg'
+
+    shutil.copytree(str(root), str(Path(backup, 'test_pkg')))
+
+    yield str(Path(importlib.util.find_spec('test_pkg').origin).parent)
+    os.chdir(old)
+
+    shutil.rmtree(str(root))
+    shutil.copytree(str(Path(backup, 'test_pkg')), str(root))
+    shutil.rmtree(backup)
 
 
 @fixture_backup('spec-with-functions')

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -22,6 +22,8 @@ def get(products):
 
 def test_signature_check():
     error = ("You are passing products. Do you mean product?")
+
     with pytest.raises(TaskRenderError) as e:
         signature_check(get, {'product': 1}, 'get')
+        
     assert error == str(e.value)

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -1,0 +1,23 @@
+import inspect
+from sklearn import datasets
+from pathlib import Path
+import pandas as pd
+
+from ploomber.util.util import signature_check
+
+def get(products):
+    """Get data
+    """
+    d = datasets.load_iris()
+
+    df = pd.DataFrame(d['data'])
+    df.columns = d['feature_names']
+    df['target'] = d['target']
+
+    Path(str(product)).parent.mkdir(exist_ok=True, parents=True)
+
+    df.to_parquet(str(product))
+
+def test_signature_check():
+    x = signature_check(get, inspect.signature(get).parameters, 'get')
+    assert x == True

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -27,3 +27,4 @@ def test_signature_check():
         signature_check(get, {'product': 1}, 'get')
         
     assert error == str(e.value)
+    

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -1,7 +1,9 @@
 import inspect
+import pytest
 from sklearn import datasets
 from pathlib import Path
 import pandas as pd
+from ploomber.exceptions import TaskRenderError
 
 from ploomber.util.util import signature_check
 
@@ -19,5 +21,7 @@ def get(products):
     df.to_parquet(str(product))
 
 def test_signature_check():
-    x = signature_check(get, inspect.signature(get).parameters, 'get')
-    assert x == True
+    error = ("You are passing products. Do you mean product?")
+    with pytest.raises(TaskRenderError) as e:
+        signature_check(get, {'product': 1}, 'get')
+    assert error == str(e.value)

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -3,10 +3,14 @@ import pytest
 from sklearn import datasets
 from pathlib import Path
 import pandas as pd
+from ploomber import dag
 from ploomber.exceptions import TaskRenderError
+from ploomber.sources.pythoncallablesource import PythonCallableSource
+from ploomber.spec.dagspec import DAGSpec
 
 from ploomber.util.util import signature_check
 
+'''
 def get(products):
     """Get data
     """
@@ -19,12 +23,22 @@ def get(products):
     Path(str(product)).parent.mkdir(exist_ok=True, parents=True)
 
     df.to_parquet(str(product))
+'''
 
 def test_signature_check():
+    
+    spec1 = {
+        'tasks': [{
+            'source': 'tasks.get',
+            'products': 'output/get.parquet',
+        }]
+    }
+
     error = ("You are passing products. Do you mean product?")
 
-    with pytest.raises(TaskRenderError) as e:
-        signature_check(get, {'product': 1}, 'get')
-        
-    assert error == str(e.value)
+    x = PythonCallableSource(str(spec1))
+    PythonCallableSource._post_render_validation(x, None, {'products': 1})
+    
+    #signature_check(get, {'product': 1}, 'get')      
+    #assert error == str(e.value)
     


### PR DESCRIPTION
Improved error message whenever a user passes `products` instead of `product` using `difflib`.
Resolves #642 