### PR TITLE
error message when .yml found instead of .yaml

### DIFF
--- a/src/ploomber/cli/parsers.py
+++ b/src/ploomber/cli/parsers.py
@@ -38,6 +38,7 @@ class CustomMutuallyExclusiveGroup(argparse._MutuallyExclusiveGroup):
     A subclass of argparse._MutuallyExclusiveGroup that determines whether
     the added args should go into the static of dynamic API
     """
+
     def add_argument(self, *args, **kwargs):
         if not self._container.finished_static_api:
             if (not self._container.in_context
@@ -65,6 +66,7 @@ class CustomParser(argparse.ArgumentParser):
     manager, only after this has happened, other arguments can be added using
     parser.add_argument.
     """
+
     def __init__(self, *args, **kwargs):
         self.DEFAULT_ENTRY_POINT = default.try_to_find_entry_point()
 
@@ -125,6 +127,9 @@ class CustomParser(argparse.ArgumentParser):
                            'Use --entry-point/-e to pass a '
                            'entry point\'s location or '
                            'place it in a standard location.\n\n'
+                           'Otherwise check if your pipeline have '
+                           '.yml as extension, '
+                           'change it to .yaml instead.\n\n'
                            'Need help? https://ploomber.io/community')
 
             return self.DEFAULT_ENTRY_POINT

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -312,7 +312,6 @@ class DAGSpec(MutableMapping):
         env = env or dict()
         path_to_defaults = default.path_to_env_from_spec(
             path_to_spec=self._path)
-
         # there is an env.yaml we can use
         if path_to_defaults:
             defaults = yaml.safe_load(Path(path_to_defaults).read_text())
@@ -322,6 +321,11 @@ class DAGSpec(MutableMapping):
 
         # there is no env.yaml
         else:
+            # wrong extension of env.yml or env.{name}.yml found
+            if default.try_to_find_env_yml(path_to_spec=self._path):
+                raise DAGSpecInitializationError(
+                    'Error: found env file ends with .yml. '
+                    'Change the extension to .yaml.')
             self.env = EnvDict(env, path_to_here=self._parent_path)
 
         self.data, tags = expand_raw_dictionary_and_extract_tags(
@@ -663,6 +667,7 @@ class DAGSpecPartial(DAGSpec):
     A DAGSpec subclass that initializes from a list of tasks (used in the
     onlinedag.py) module
     """
+
     def __init__(self, path_to_partial, env=None):
         with open(path_to_partial) as f:
             tasks = yaml.safe_load(f)

--- a/tests/util/test_default.py
+++ b/tests/util/test_default.py
@@ -266,6 +266,24 @@ def test_path_to_env_error_if_dir(tmp_directory):
     assert str(excinfo.value) == expected
 
 
+def test_find_env_yml(tmp_directory):
+    Path('dir').mkdir()
+    Path('dir', 'env.yml').touch()
+
+    assert default.try_to_find_env_yml('dir/pipeline.yaml') == str(
+        Path('dir', 'env.yml').resolve())
+
+
+def test_find_env_yml_with_name(tmp_directory):
+    Path('env.train.yml').touch()
+    Path('dir').mkdir()
+    Path('dir', 'pipeline.train.yaml').touch()
+
+    assert default.try_to_find_env_yml(
+        Path('dir',
+             'pipeline.train.yaml')) == str(Path('env.train.yml').resolve())
+
+
 def test_finds_pipeline_yaml(tmp_directory):
     expected = Path(tmp_directory).resolve()
     pip = Path('pipeline.yaml').resolve()


### PR DESCRIPTION
## Describe your changes

When users have pipeline, env file ends with .yml extension, output error message reminding them to rename to .yaml instead.

## Issue ticket number and link
Closes #659

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

