### PR TITLE
Fix write-pipeline typo in Cloud documentation

### DIFF
--- a/doc/cloud/monitoring.rst
+++ b/doc/cloud/monitoring.rst
@@ -85,7 +85,7 @@ To write a pipeline you can leverage this command:
 
 .. code-block:: console
 
-    ploomber cloud delete-pipeline <YOUR_PIPELINE_ID> <PIPELINE_STATUS>
+    ploomber cloud write-pipeline <YOUR_PIPELINE_ID> <PIPELINE_STATUS>
 
 The `pipeline_id` and `status` arguments are required.
 


### PR DESCRIPTION
## Describe your changes
Fix typo in Cloud documentation. Should be `write-pipeline` command 
`ploomber cloud write-pipeline <YOUR_PIPELINE_ID> <PIPELINE_STATUS>`

which is defined in https://github.com/ploomber/ploomber/blob/ff4bbda39b57101eea4c18eae7911585d90b5831/src/ploomber/cli/cloud.py#L114-L125

## Issue ticket number and link
N/A

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

