### PR TITLE
Disable commit signing in tests

### DIFF
--- a/tests/cli/test_nb.py
+++ b/tests/cli/test_nb.py
@@ -14,6 +14,7 @@ from ploomber.cli import nb
 
 def git_init():
     subprocess.check_call(['git', 'init'])
+    subprocess.check_call(['git', 'config', 'commit.gpgsign', 'false'])
     subprocess.check_call(['git', 'config', 'user.email', 'ci@ploomberio'])
     subprocess.check_call(['git', 'config', 'user.name', 'Ploomber'])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def git_init():
         raise ValueError('call git_init in a temporary directory')
 
     subprocess.run(['git', 'init', '-b', 'mybranch'])
+    subprocess.check_call(['git', 'config', 'commit.gpgsign', 'false'])
     subprocess.check_call(['git', 'config', 'user.email', 'ci@ploomberio'])
     subprocess.check_call(['git', 'config', 'user.name', 'Ploomber'])
 

--- a/tests/env/test_sample_project_expanders.py
+++ b/tests/env/test_sample_project_expanders.py
@@ -20,6 +20,7 @@ def test_get_git(tmp_directory, cleanup_env):
     Path('env.yaml').write_text('_module: .\ngit: "{{git}}"')
 
     subprocess.run(['git', 'init'])
+    subprocess.check_call(['git', 'config', 'commit.gpgsign', 'false'])
     subprocess.run(['git', 'config', 'user.email', 'ci@ploomberio'])
     subprocess.run(['git', 'config', 'user.name', 'Ploomber'])
     subprocess.run(['git', 'add', '--all'])


### PR DESCRIPTION
I was having an issue where the tests would ask for my gpg passphrase to sign commits during the tests which isnt ideal

## Describe your changes

I added a line before the tests to disable gpg signing in the git config

Would be better if global state could be ignored entirely but this fixes
the tests asking for gpg passphrases

## Issue ticket number and link
Closes #x 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

