### PR TITLE
clean traceback when using ploomber task (#828)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 * Fixes jinja extractor when upstream had nested getitem ([#859](https://github.com/ploomber/ploomber/issues/859))
 * Fixes notebook loading on Windows when UTF-8 is not the default encoding ([#870](https://github.com/ploomber/ploomber/issues/870))
 
+* Remove extraneous output in `ploomber task` tracebacks ([#828]https://github.com/ploomber/ploomber/issues/828)
+
 ## 0.19.6 (2022-06-02)
 * `setup.cfg` allows to switch default entry point
 * Generate multiple notebook products from a single task ([#708](https://github.com/ploomber/ploomber/issues/708))

--- a/src/ploomber/cli/task.py
+++ b/src/ploomber/cli/task.py
@@ -85,17 +85,23 @@ def _task_cli(accept_task_id=False):
     # the --build flag is required
     no_flags = not any((args.build, args.status, args.source, args.on_finish))
 
+    err = None
+
     if no_flags or args.build:
         try:
             task.build(force=args.force)
         except Exception as e:
+            err = e
+
+        if err is not None:
             if getattr(args, 'task_id', None):
                 api.tasks_update(getattr(args, 'task_id'), 'failed')
 
+            msg = _format.exception(err)
             exception_string = task_build_exception(task=task,
-                                                    message=_format
-                                                    .exception(e),
-                                                    exception=e)
+                                                    message=msg,
+                                                    exception=err)
+
             raise TaskBuildError(exception_string)
         else:
             click.echo(f"{task.name!r} task executed successfully!")

--- a/src/ploomber/exceptions.py
+++ b/src/ploomber/exceptions.py
@@ -94,7 +94,7 @@ class TaskInitializationError(BaseException):
     pass
 
 
-class TaskBuildError(Exception):
+class TaskBuildError(BaseException):
     """Raise when a task fails to build
     """
     pass

--- a/src/ploomber/executors/_format.py
+++ b/src/ploomber/executors/_format.py
@@ -11,14 +11,18 @@ def exception(exc):
     Parameters
     ----------
     """
+
+    # extract all the exception objects, in case this is a chained exception
     exceptions = [exc]
 
     while exc.__cause__:
         exceptions.append(exc.__cause__)
         exc = exc.__cause__
 
+    # reverse to get the most specific error first
     exceptions.reverse()
 
+    # find the first instance of TaskBuildError
     breakpoint = None
 
     for i, exc in enumerate(exceptions):
@@ -26,12 +30,24 @@ def exception(exc):
             breakpoint = i
             break
 
-    exc_hide = exceptions[breakpoint:]
+    # using the breakpoint, find the exception where we'll only display the
+    # error message, not the traceback. That is, the first TaskBuildError
+    # exception
+    exc_short = exceptions[breakpoint:]
 
     if breakpoint is not None:
-        tr = _format_exception(exceptions[breakpoint - 1])
+        # this happens when running a single task, all exception can be
+        # TaskBuildError
+        if breakpoint != 0:
+            # traceback info applies to non-TaskBuildError
+            # (this takes care of chained exceptions as well)
+            tr = _format_exception(exceptions[breakpoint - 1])
+        else:
+            tr = ''
+
+        # append the short exceptions (only error message)
         tr = tr + '\n' + '\n'.join(f'{_get_exc_name(exc)}: {str(exc)}'
-                                   for exc in exc_hide)
+                                   for exc in exc_short)
     else:
         # if not breakpoint, take the outermost exception and show it.
         # this ensures we show the full traceback in case there are chained
@@ -46,10 +62,14 @@ def _get_exc_name(exc):
 
 
 def _format_exception(exc):
+    # for these ones, the traceback isn't important, so just display the
+    # message
     if isinstance(exc,
                   (PapermillExecutionError, RenderError, TaskRenderError)):
         tr = str(exc)
     else:
+        # format the exception, this will take care of chained exceptions
+        # as well
         tr = ''.join(
             traceback.format_exception(type(exc),
                                        exc,

--- a/src/ploomber/messagecollector.py
+++ b/src/ploomber/messagecollector.py
@@ -118,6 +118,19 @@ class MessageCollector(abc.ABC):
             yield message
 
 
+# gets the message for a single task
+def task_build_exception(task, message, exception):
+    # use this just to get a single task collected from the abstract class
+    class TaskBuildExceptionsCollector(MessageCollector):
+        def __str__(self):
+            return self._to_str(name='Task build failed',
+                                file=None,
+                                writer_kwargs=dict(red=True))
+    tbec = TaskBuildExceptionsCollector()
+    tbec.append(task=task, message=message, obj=exception)
+    return str(tbec)
+
+
 class BuildExceptionsCollector(MessageCollector):
     def __str__(self):
         return self._to_str(name='DAG build failed',

--- a/src/ploomber/messagecollector.py
+++ b/src/ploomber/messagecollector.py
@@ -4,6 +4,7 @@ from io import StringIO
 
 
 class Message:
+
     def __init__(self, task, message, obj=None):
         self._task = task
         self._message = message
@@ -36,6 +37,7 @@ class MessageCollector(abc.ABC):
     one is shown along with the task name it generated it.
 
     """
+
     def __init__(self, messages=None):
         self.messages = messages or []
 
@@ -46,7 +48,11 @@ class MessageCollector(abc.ABC):
     def __str__(self):
         pass
 
-    def _to_str(self, name=None, file=None, writer_kwargs=None):
+    def _to_str(self,
+                name=None,
+                file=None,
+                writer_kwargs=None,
+                show_summary=True):
         """
         Return the string representation of the collected messages
 
@@ -85,14 +91,15 @@ class MessageCollector(abc.ABC):
 
             self.tw._write_source(msg.message.splitlines(), lexer='pytb')
 
-        n = len(self)
-        t = 'task' if n == 1 else 'tasks'
-        self.tw.sep('=', title=f'Summary ({n} {t})', **writer_kwargs)
+        if show_summary:
+            n = len(self)
+            t = 'task' if n == 1 else 'tasks'
+            self.tw.sep('=', title=f'Summary ({n} {t})', **writer_kwargs)
 
-        for msg in self.messages:
-            # TODO: include original exception type and error message in
-            # summary
-            self.tw.write(f'{msg.header}\n')
+            for msg in self.messages:
+                # TODO: include original exception type and error message in
+                # summary
+                self.tw.write(f'{msg.header}\n')
 
         if name:
             self.tw.sep('=', title=name, **writer_kwargs)
@@ -122,16 +129,20 @@ class MessageCollector(abc.ABC):
 def task_build_exception(task, message, exception):
     # use this just to get a single task collected from the abstract class
     class TaskBuildExceptionsCollector(MessageCollector):
+
         def __str__(self):
             return self._to_str(name='Task build failed',
                                 file=None,
-                                writer_kwargs=dict(red=True))
+                                writer_kwargs=dict(red=True),
+                                show_summary=False)
+
     tbec = TaskBuildExceptionsCollector()
     tbec.append(task=task, message=message, obj=exception)
     return str(tbec)
 
 
 class BuildExceptionsCollector(MessageCollector):
+
     def __str__(self):
         return self._to_str(name='DAG build failed',
                             file=None,
@@ -139,6 +150,7 @@ class BuildExceptionsCollector(MessageCollector):
 
 
 class RenderExceptionsCollector(MessageCollector):
+
     def __str__(self):
         return self._to_str(name='DAG render failed',
                             file=None,
@@ -146,6 +158,7 @@ class RenderExceptionsCollector(MessageCollector):
 
 
 class BuildWarningsCollector(MessageCollector):
+
     def __str__(self):
         return self._to_str(name='DAG build with warnings',
                             file=None,
@@ -153,6 +166,7 @@ class BuildWarningsCollector(MessageCollector):
 
 
 class RenderWarningsCollector(MessageCollector):
+
     def __str__(self):
         return self._to_str(name='DAG render with warnings',
                             file=None,

--- a/tests/test_messagecollector.py
+++ b/tests/test_messagecollector.py
@@ -1,0 +1,28 @@
+import ploomber.messagecollector as mc
+from ploomber.products import File
+from ploomber.tasks import DownloadFromURL
+from ploomber import DAG
+
+
+def test_task_build_exception_works_for_valid_args():
+    dag = DAG()
+
+    url = """
+    https://google.com
+    """
+    task = DownloadFromURL(url, File('file'), dag=dag, name='download')
+
+    exceptionText = mc.task_build_exception(task=task,
+                                            message="hello",
+                                            exception=Exception("hello)"))
+
+    expected = """
+============================== Task build failed ===============================
+------------------ DownloadFromURL: download -> File('file') -------------------
+hello
+=============================== Summary (1 task) ===============================
+DownloadFromURL: download -> File('file')
+============================== Task build failed ===============================
+"""  # noqa: E501
+
+    assert exceptionText == expected

--- a/tests/test_messagecollector.py
+++ b/tests/test_messagecollector.py
@@ -2,9 +2,13 @@ import ploomber.messagecollector as mc
 from ploomber.products import File
 from ploomber.tasks import DownloadFromURL
 from ploomber import DAG
+from tests_util import set_terminal_output_columns
 
 
-def test_task_build_exception_works_for_valid_args():
+def test_task_build_exception_works_for_valid_args(monkeypatch):
+    # hardcode terminal width to be consistent for ci on different platforms
+    set_terminal_output_columns(80, monkeypatch)
+
     dag = DAG()
 
     url = """

--- a/tests/test_messagecollector.py
+++ b/tests/test_messagecollector.py
@@ -20,8 +20,6 @@ def test_task_build_exception_works_for_valid_args():
 ============================== Task build failed ===============================
 ------------------ DownloadFromURL: download -> File('file') -------------------
 hello
-=============================== Summary (1 task) ===============================
-DownloadFromURL: download -> File('file')
 ============================== Task build failed ===============================
 """  # noqa: E501
 

--- a/tests/tests_util.py
+++ b/tests/tests_util.py
@@ -3,9 +3,11 @@ This functions are imported in some tests
 """
 import ast
 from pathlib import Path
+import sys
 
 from ploomber.executors import Serial
 from itertools import product
+import ploomber.io.terminalwriter as terminalwriter
 
 
 def expand_grid(grid):
@@ -47,3 +49,16 @@ def assert_function_in_module(function_name, module_file):
         for element in module.body if hasattr(element, 'name')
     }
     assert function_name in names
+
+
+def set_terminal_output_columns(num_cols: int, monkeypatch):
+    """
+    Sets the number of columns for terminalwriter
+    Usefult for ci where the number of columns is inconsistent
+    """
+    # countaract lines in sep() of terminalwriter.py that removes a col from
+    # the width if on windows
+    if sys.platform == "win32":
+        num_cols += 1
+
+    monkeypatch.setattr(terminalwriter, "get_terminal_width", lambda: num_cols)


### PR DESCRIPTION
## Describe your changes

Uses _format to format errors in individual tasks

## Issue ticket number and link
Closes #828 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.


I'm not sure if these changes get the behavior we want:

Here I have an example open and I have run `ploomber build`. I then run `ploomber task fit`:

Before _format:
```
(ploomber) conda-shell-chrootenv:prem@morokei:~/Documents/projects/ploomber/ploomberw/test/example$ ploomber task fit
Loading pipeline...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 16054.75it/s]
Traceback (most recent call last):
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 554, in _build
    res = self._run()
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 638, in _run
    raise TaskBuildError('Attempted to run task "{}", whose '
ploomber.exceptions.TaskBuildError: Attempted to run task "fit", whose status TaskStatus.Skipped. Render again and set force=True if you want to force execution

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/cli/io.py", line 52, in wrapper
    fn(**kwargs)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/telemetry/telemetry.py", line 500, in wrapper
    raise e
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/telemetry/telemetry.py", line 488, in wrapper
    result = func(*args, **kwargs)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/cli/task.py", line 76, in main
    _task_cli()
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/cli/task.py", line 61, in _task_cli
    task.build(force=args.force)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 522, in build
    res, _ = self._build(catch_exceptions=catch_exceptions)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 573, in _build
    raise TaskBuildError(msg) from e
ploomber.exceptions.TaskBuildError: Error building task "fit"

ploomber.exceptions.TaskBuildError: Attempted to run task "fit", whose status TaskStatus.Skipped. Render again and set force=True if you want to force execution
ploomber.exceptions.TaskBuildError: Error building task "
```


After _format:
```
(ploomber) conda-shell-chrootenv:prem@morokei:~/Documents/projects/ploomber/ploomberw/test/example$ ploomber task fit 
Loading pipeline...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 18315.74it/s]
Traceback (most recent call last):
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 554, in _build
    res = self._run()
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 638, in _run
    raise TaskBuildError('Attempted to run task "{}", whose '
ploomber.exceptions.TaskBuildError: Attempted to run task "fit", whose status TaskStatus.Skipped. Render again and set force=True if you want to force execution

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/cli/task.py", line 64, in _task_cli
    task.build(force=args.force)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 522, in build
    res, _ = self._build(catch_exceptions=catch_exceptions)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 573, in _build
    raise TaskBuildError(msg) from e
ploomber.exceptions.TaskBuildError: Error building task "fit"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/cli/io.py", line 52, in wrapper
    fn(**kwargs)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/telemetry/telemetry.py", line 500, in wrapper
    raise e
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/telemetry/telemetry.py", line 488, in wrapper
    result = func(*args, **kwargs)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/cli/task.py", line 84, in main
    _task_cli()
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/cli/task.py", line 73, in _task_cli
    raise TaskBuildError(exception_string)
ploomber.exceptions.TaskBuildError: 
================================================================================================ Task build failed =================================================================================================
----------------------------------------------------- NotebookRunner: fit -> MetaProduct({'model': File('output/model.pickle'), 'nb': File('output/nb.html')}) -----------------------------------------------------
--------------------------------------------------------------------- /home/prem/Documents/projects/ploomber/ploomberw/test/example/fit.ipynb ----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 554, in _build
    res = self._run()
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 638, in _run
    raise TaskBuildError('Attempted to run task "{}", whose '
ploomber.exceptions.TaskBuildError: Attempted to run task "fit", whose status TaskStatus.Skipped. Render again and set force=True if you want to force execution

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/cli/task.py", line 64, in _task_cli
    task.build(force=args.force)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 522, in build
    res, _ = self._build(catch_exceptions=catch_exceptions)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 573, in _build
    raise TaskBuildError(msg) from e
ploomber.exceptions.TaskBuildError: Error building task "fit"

ploomber.exceptions.TaskBuildError: Attempted to run task "fit", whose status TaskStatus.Skipped. Render again and set force=True if you want to force execution
ploomber.exceptions.TaskBuildError: Error building task "fit"
================================================================================================= Summary (1 task) =================================================================================================
NotebookRunner: fit -> MetaProduct({'model': File('output/model.pickle'), 'nb': File('output/nb.html')})
================================================================================================ Task build failed =================================================================================================


ploomber.exceptions.TaskBuildError: 
================================================================================================ Task build failed =================================================================================================
----------------------------------------------------- NotebookRunner: fit -> MetaProduct({'model': File('output/model.pickle'), 'nb': File('output/nb.html')}) -----------------------------------------------------
--------------------------------------------------------------------- /home/prem/Documents/projects/ploomber/ploomberw/test/example/fit.ipynb ----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 554, in _build
    res = self._run()
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 638, in _run
    raise TaskBuildError('Attempted to run task "{}", whose '
ploomber.exceptions.TaskBuildError: Attempted to run task "fit", whose status TaskStatus.Skipped. Render again and set force=True if you want to force execution

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/cli/task.py", line 64, in _task_cli
    task.build(force=args.force)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 522, in build
    res, _ = self._build(catch_exceptions=catch_exceptions)
  File "/home/prem/Documents/projects/ploomber/ploomberw/ploomber/src/ploomber/tasks/abc.py", line 573, in _build
    raise TaskBuildError(msg) from e
ploomber.exceptions.TaskBuildError: Error building task "fit"

ploomber.exceptions.TaskBuildError: Attempted to run task "fit", whose status TaskStatus.Skipped. Render again and set force=True if you want to force execution
ploomber.exceptions.TaskBuildError: Error building task "fit"
================================================================================================= Summary (1 task) =================================================================================================
NotebookRunner: fit -> MetaProduct({'model': File('output/model.pickle'), 'nb': File('output/nb.html')})
================================================================================================

```

I'm not sure why the exception gets longer. I went through pdb and wasn't really sure what was going on.

For this case though, I think it would be better if it printed something like `task already built. run  "ploomber task fit --force" to force rebuild`