### PR TITLE
Fixed confusing error when passing something.html as source #646

### DIFF
--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -5,6 +5,7 @@ Note: All validation errors should raise DAGSpecInitializationError, this
 allows the CLI to signal that this is a user's input error and hides the
 traceback and only displays the error message
 """
+import mimetypes
 from functools import partial
 from copy import copy, deepcopy
 from pathlib import Path
@@ -46,6 +47,10 @@ def _looks_like_path(s):
         return '\\' in s
     else:
         return '/' in s
+
+
+def _loos_like_file_name(s):
+    return mimetypes.guess_type(s)[0] is not None
 
 
 def _extension_typo(extension, valid_extensions):
@@ -111,11 +116,17 @@ def task_class_from_source_str(source_str, lazy_import, reload, product):
             error = e
 
         if imported is None:
-            raise DAGSpecInitializationError(
-                'Failed to determine task class for '
-                f'source {source_str!r}: {error!s}.\nValid extensions '
-                f'are: {pretty_print.iterable(suffix2taskclass)}\n'
-                'If you meant to import a function, please rename it.')
+            if _loos_like_file_name(source_str):
+                raise DAGSpecInitializationError(
+                    'Failed to determine task class for '
+                    f'source {source_str!r} (invalid '
+                    f'extension {extension!r}). Valid extensions '
+                    f'are: {pretty_print.iterable(suffix2taskclass)}\n'
+                    'If you meant to import a function, please rename it.')
+            else:
+                raise DAGSpecInitializationError(
+                    'Failed to determine task class for '
+                    f'source {source_str!r}: {error!s}.')
         else:
             return tasks.PythonCallable
     else:

--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -113,8 +113,7 @@ def task_class_from_source_str(source_str, lazy_import, reload, product):
         if imported is None:
             raise DAGSpecInitializationError(
                 'Failed to determine task class for '
-                f'source {source_str!r}: {error!s}. (invalid '
-                f'extension {extension!r}). Valid extensions '
+                f'source {source_str!r}: {error!s}.\nValid extensions '
                 f'are: {pretty_print.iterable(suffix2taskclass)}\n'
                 'If you meant to import a function, please rename it.')
         else:

--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -49,7 +49,7 @@ def _looks_like_path(s):
         return '/' in s
 
 
-def _loos_like_file_name(s):
+def _looks_like_file_name(s):
     return mimetypes.guess_type(s)[0] is not None
 
 
@@ -116,7 +116,7 @@ def task_class_from_source_str(source_str, lazy_import, reload, product):
             error = e
 
         if imported is None:
-            if _loos_like_file_name(source_str):
+            if _looks_like_file_name(source_str):
                 raise DAGSpecInitializationError(
                     'Failed to determine task class for '
                     f'source {source_str!r} (invalid '

--- a/tests/spec/test_taskspec.py
+++ b/tests/spec/test_taskspec.py
@@ -27,6 +27,7 @@ def test_task_class_from_script(tmp_directory, source_str, expected):
 @pytest.mark.parametrize('source_str', [
     str(Path('something', 'script.md')),
     str(Path('something', 'another', 'script.json')),
+    str(Path('file.html'))
 ])
 def test_task_class_from_script_unknown_extension(tmp_directory, source_str):
     with pytest.raises(DAGSpecInitializationError) as excinfo:

--- a/tests/spec/test_taskspec.py
+++ b/tests/spec/test_taskspec.py
@@ -27,7 +27,10 @@ def test_task_class_from_script(tmp_directory, source_str, expected):
 @pytest.mark.parametrize('source_str', [
     str(Path('something', 'script.md')),
     str(Path('something', 'another', 'script.json')),
-    str(Path('file.html'))
+    str(Path('file.html')),
+    str(Path('file.json')),
+    str(Path('file.xy')),
+    str(Path('file.a'))
 ])
 def test_task_class_from_script_unknown_extension(tmp_directory, source_str):
     with pytest.raises(DAGSpecInitializationError) as excinfo:

--- a/tests/spec/test_taskspec.py
+++ b/tests/spec/test_taskspec.py
@@ -27,10 +27,9 @@ def test_task_class_from_script(tmp_directory, source_str, expected):
 @pytest.mark.parametrize('source_str', [
     str(Path('file.html')),
     str(Path('file.json')),
-    str(Path('a.a')),
-    str(Path('file.b'))
+    str(Path('file.a'))
 ])
-def test_task_class_from_file_without_path_unknown_extension(
+def test_task_class_from_valid_file_without_path_unsupported_extension(
         tmp_directory, source_str):
     with pytest.raises(DAGSpecInitializationError) as excinfo:
         task_class_from_source_str(source_str,

--- a/tests/spec/test_taskspec.py
+++ b/tests/spec/test_taskspec.py
@@ -25,12 +25,28 @@ def test_task_class_from_script(tmp_directory, source_str, expected):
 
 
 @pytest.mark.parametrize('source_str', [
-    str(Path('something', 'script.md')),
-    str(Path('something', 'another', 'script.json')),
     str(Path('file.html')),
     str(Path('file.json')),
-    str(Path('file.xy')),
-    str(Path('file.a'))
+    str(Path('a.a')),
+    str(Path('file.b'))
+])
+def test_task_class_from_file_without_path_unknown_extension(
+        tmp_directory, source_str):
+    with pytest.raises(DAGSpecInitializationError) as excinfo:
+        task_class_from_source_str(source_str,
+                                   lazy_import=False,
+                                   reload=False,
+                                   product=None)
+
+    assert 'Failed to determine task class' in str(excinfo.value)
+    assert 'invalid extension' in str(excinfo.value)
+    assert 'If you meant to import a function, please rename it.' in str(
+        excinfo.value)
+
+
+@pytest.mark.parametrize('source_str', [
+    str(Path('something', 'script.md')),
+    str(Path('something', 'another', 'script.json'))
 ])
 def test_task_class_from_script_unknown_extension(tmp_directory, source_str):
     with pytest.raises(DAGSpecInitializationError) as excinfo:


### PR DESCRIPTION
## Describe your changes
1. "_looks_like_path" checks a path. I've added another check if the user passed just a file name (is_path is false). We check if this file has a known extension with mimetypes. If so, this should throw the appropriate error ("Invalid extension"). Otherwise, it might be a dotted path.
2. "If you meant to import a function, please rename it." added at the end of the existing error message since there's a slight chance of a false positive where the user really wants to import a function named as the file's extension. 
3. A single file name without a path added to existing test function (test_task_class_from_script_unknown_extension)

## Issue ticket number and link
Issue number: 646
Closes #646 

## Checklist before requesting a review
- [X ] I have performed a self-review of my code
- [X ] I have added thorough tests (when necessary).
- [ ] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

