### PR TITLE
Remove parameters cell missing exception and add cell when it is missing instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 0.20.1dev
+* Remove `parameters` cell missing exception and add `parameters` cell in `NotebookRunner` and `ScriptRunner` when it is missing ([#971](https://github.com/ploomber/ploomber/issues/971))
 
 ## 0.20 (2022-08-04)
 

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -401,11 +401,13 @@ class NotebookSource(Source):
                                   extract_product=False):
         '''Check parameters call and add it when it's missing
 
-        Keyword arguments:
-        extract_upstream -- Flags used to determine the content of
-        the parameters cell, only used if the notebook is
-        missing the parameters cell (default False)
-        extract_product -- Same as extract_upstream (default False)
+        Parameters
+        ----------
+        extract_upstream : bool, default: True
+            Flags used to determine the content of the parameters cell,
+            only used if the notebook is missing the parameters cell
+        extract_product : bool, default: True
+            Same as extract_upstream (default False)
         '''
         params_cell, _ = find_cell_with_tag(self._nb_obj_unrendered,
                                             'parameters')
@@ -1053,10 +1055,7 @@ product = None
 """
 
     if not extract_upstream and not extract_product:
-        source += """
-upstream = None
-product = None
-"""
+        source += '# add default values for parameters here'
 
     c = JupytextConfiguration()
     c.notebook_metadata_filter

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -402,7 +402,8 @@ class NotebookSource(Source):
                                             'parameters')
 
         if params_cell is None:
-            loc = ' "{}"'.format(pretty_print.try_relative_path(self.loc)) if self.loc else ''
+            loc = ' "{}"'.format(pretty_print.try_relative_path(self.loc)) \
+                if self.loc else ''
             msg = ('Notebook{} does not have a cell tagged '
                    '"parameters"'.format(loc))
 

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -1020,7 +1020,7 @@ def _warn_on_unused_params(nb, params):
     _, idx = find_cell_with_tag(nb, 'parameters')
 
     # the notebooks might not have a parameters cell
-    if not idx:
+    if idx is None:
         return
 
     del nb.cells[idx]

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -423,6 +423,30 @@ Go to: https://ploomber.io/s/params for more information
                         'details: https://ploomber.io/s/params')
             click.secho(msg)
 
+    def _validate_parameters_cell(self,
+                                  extract_upstream=False,
+                                  extract_product=False):
+        '''Check parameters call and add it when it's missing
+
+        Keyword arguments:
+        extract_upstream -- Flags used to determine the content of
+        the parameters cell, only used if the notebook is
+        missing the parameters cell (default False)
+        extract_product -- Same as extract_upstream (default False)
+        '''
+        params_cell, _ = find_cell_with_tag(self._nb_obj_unrendered,
+                                            'parameters')
+
+        if params_cell is None:
+            loc = pretty_print.try_relative_path(self.loc)
+            add_parameters_cell(self.loc,
+                                extract_upstream,
+                                extract_product)
+            click.secho(
+                f'Notebook {loc} is missing the parameters cell, '
+                'adding it at the top of the file...',
+                fg='yellow')
+
     def _post_render_validation(self):
         """
         Validate params passed against parameters in the notebook

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -317,7 +317,8 @@ class NotebookSource(Source):
         # the latest version
         _, nb = self._read_nb_str_unrendered()
 
-        if 'parameters' in _get_last_cell(nb).metadata.get('tags', []):
+        if nb.cells and 'parameters' in _get_last_cell(nb).metadata.get(
+                'tags', []):
             cell_suggestion = _get_cell_suggestion(nb)
             kind = 'notebook' if self._ext_in == 'ipynb' else 'script'
             raise SourceInitializationError(
@@ -414,9 +415,7 @@ class NotebookSource(Source):
 
         if params_cell is None:
             loc = pretty_print.try_relative_path(self.loc)
-            add_parameters_cell(self.loc,
-                                extract_upstream,
-                                extract_product)
+            add_parameters_cell(self.loc, extract_upstream, extract_product)
             click.secho(
                 f'Notebook {loc} is missing the parameters cell, '
                 'adding it at the top of the file...',
@@ -1019,6 +1018,11 @@ def _nb2codestr(nb):
 def _warn_on_unused_params(nb, params):
     nb = deepcopy(nb)
     _, idx = find_cell_with_tag(nb, 'parameters')
+
+    # the notebooks might not have a parameters cell
+    if not idx:
+        return
+
     del nb.cells[idx]
 
     code = _nb2codestr(nb)

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -394,34 +394,7 @@ class NotebookSource(Source):
         Validate notebook after initialization (run pyflakes to detect
         syntax errors)
         """
-        # NOTE: what happens if I pass source code with errors to parso?
-        # maybe we don't need to use pyflakes after all
-        # we can also use compile. can pyflakes detect things that
-        # compile cannot?
-        params_cell, _ = find_cell_with_tag(self._nb_obj_unrendered,
-                                            'parameters')
-
-        if params_cell is None:
-            loc = ' "{}"'.format(pretty_print.try_relative_path(self.loc)) \
-                if self.loc else ''
-            msg = ('Notebook{} does not have a cell tagged '
-                   '"parameters"'.format(loc))
-
-            if self.loc and Path(self.loc).suffix == '.py':
-                msg += """.
-Add a cell at the top like this:
-
-# %% tags=["parameters"]
-upstream = None
-product = None
-
-Go to: https://ploomber.io/s/params for more information
-"""
-            if self.loc and Path(self.loc).suffix == '.ipynb':
-                msg += ('. Add a cell at the top and tag it as "parameters". '
-                        'Go to the next URL for '
-                        'details: https://ploomber.io/s/params')
-            click.secho(msg)
+        pass
 
     def _validate_parameters_cell(self,
                                   extract_upstream=False,
@@ -1076,6 +1049,12 @@ upstream = None
     if extract_product:
         source += """\
 # declare a dictionary with the outputs of this task
+product = None
+"""
+
+    if not extract_upstream and not extract_product:
+        source += """
+upstream = None
 product = None
 """
 

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -403,11 +403,11 @@ class NotebookSource(Source):
 
         Parameters
         ----------
-        extract_upstream : bool, default: True
+        extract_upstream : bool, default: False
             Flags used to determine the content of the parameters cell,
             only used if the notebook is missing the parameters cell
-        extract_product : bool, default: True
-            Same as extract_upstream (default False)
+        extract_product : bool, default: False
+            Same as extract_upstream
         '''
         params_cell, _ = find_cell_with_tag(self._nb_obj_unrendered,
                                             'parameters')

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -804,24 +804,13 @@ def process_tasks(dag, dag_spec, root_path=None):
     # first pass: init tasks and them to dag
     for task_dict in dag_spec['tasks']:
         # init source to extract product
+
+
         fn = task_dict['class']._init_source
+        task_dict['extract_up'] = extract_up
+        task_dict['extract_prod'] = extract_prod
         kwargs = {'kwargs': {}, **task_dict}
-
-        try:
-            source = call_with_dictionary(fn, kwargs=kwargs)
-        except MissingParametersCellError:
-            missing_params = True
-        else:
-            missing_params = False
-
-        if missing_params:
-            click.secho(
-                f'{kwargs["source"]} is missing the parameters cell, '
-                'adding it at the top of the file...',
-                fg='yellow')
-            notebooksource.add_parameters_cell(kwargs['source'], extract_up,
-                                               extract_prod)
-            source = call_with_dictionary(fn, kwargs=kwargs)
+        source = call_with_dictionary(fn, kwargs=kwargs)
 
         if extract_prod:
             task_dict['product'] = source.extract_product()

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -83,7 +83,6 @@ is implemented by OnlineDAG, which takes a partial definition
 predictions using ``OnlineDAG().predict()``. See ``OnlineDAG`` documentation
 for details.
 """
-import click
 import fnmatch
 import os
 import yaml
@@ -103,8 +102,7 @@ from ploomber.spec.taskspec import TaskSpec, suffix2taskclass
 from ploomber.util import validate
 from ploomber.util import default
 from ploomber.dag.dagconfiguration import DAGConfiguration
-from ploomber.exceptions import (DAGSpecInitializationError,
-                                 MissingParametersCellError)
+from ploomber.exceptions import DAGSpecInitializationError
 from ploomber.env.envdict import EnvDict
 from ploomber.env.expand import (expand_raw_dictionary_and_extract_tags,
                                  expand_raw_dictionaries_and_extract_tags)
@@ -114,7 +112,6 @@ from ploomber.validators.string import (validate_product_class_name,
                                         validate_task_class_name)
 from ploomber.executors import Parallel
 from ploomber.io import pretty_print
-from ploomber.sources import notebooksource
 
 logger = logging.getLogger(__name__)
 pp = pprint.PrettyPrinter(indent=4)
@@ -804,12 +801,9 @@ def process_tasks(dag, dag_spec, root_path=None):
     # first pass: init tasks and them to dag
     for task_dict in dag_spec['tasks']:
         # init source to extract product
-
-
         fn = task_dict['class']._init_source
-        task_dict['extract_up'] = extract_up
-        task_dict['extract_prod'] = extract_prod
-        kwargs = {'kwargs': {}, **task_dict}
+        kwargs = {'kwargs': {}, 'extract_up': extract_up,
+                  'extract_prod': extract_prod, **task_dict}
         source = call_with_dictionary(fn, kwargs=kwargs)
 
         if extract_prod:

--- a/src/ploomber/tasks/notebook.py
+++ b/src/ploomber/tasks/notebook.py
@@ -274,18 +274,24 @@ class NotebookMixin(FileLoaderMixin):
 
     @staticmethod
     def _validate_parameters_cell(source,
-                                  extract_up=False,
-                                  extract_prod=False):
+                                  extract_upstream=False,
+                                  extract_product=False):
+        '''Check parameters call and add it when it's missing
+
+        Keyword arguments:
+        extract_upstream -- Flags used to determine the content of
+        the parameters cell, only used if the notebook is
+        missing the parameters cell (default False)
+        extract_product -- Same as extract_upstream (default False)
+        '''
         params_cell, _ = find_cell_with_tag(source._nb_obj_unrendered,
                                             'parameters')
 
         if params_cell is None:
             loc = pretty_print.try_relative_path(source.loc)
-            # raise MissingParametersCellError(msg)
-            # import pdb; pdb.set_trace()
             notebooksource.add_parameters_cell(source.loc,
-                                               extract_up,
-                                               extract_prod)
+                                               extract_upstream,
+                                               extract_product)
             click.secho(
                 f'Notebook {loc} is missing the parameters cell, '
                 'adding it at the top of the file...',
@@ -691,9 +697,7 @@ class NotebookRunner(NotebookMixin, Task):
                  nbconvert_export_kwargs=None,
                  local_execution=False,
                  check_if_kernel_installed=True,
-                 debug_mode=None,
-                 extract_up=False,
-                 extract_prod=False
+                 debug_mode=None
                  ):
         self.papermill_params = papermill_params or {}
         self.nbconvert_export_kwargs = nbconvert_export_kwargs or {}
@@ -722,8 +726,8 @@ class NotebookRunner(NotebookMixin, Task):
             kernelspec_name,
             static_analysis,
             check_if_kernel_installed,
-            extract_up,
-            extract_prod
+            False,
+            False
         )
         super().__init__(product, dag, name, params)
 
@@ -949,16 +953,14 @@ class ScriptRunner(NotebookMixin, Task):
                  ext_in=None,
                  static_analysis='regular',
                  local_execution=False,
-                 extract_up=False,
-                 extract_prod=False
                  ):
         self.ext_in = ext_in
         self.local_execution = local_execution
 
         kwargs = dict(hot_reload=dag._params.hot_reload)
         self._source = ScriptRunner._init_source(source, kwargs, ext_in,
-                                                 static_analysis, extract_up,
-                                                 extract_prod)
+                                                 static_analysis, False,
+                                                 False)
         super().__init__(product, dag, name, params)
 
     @staticmethod

--- a/src/ploomber/tasks/notebook.py
+++ b/src/ploomber/tasks/notebook.py
@@ -970,8 +970,6 @@ class ScriptRunner(NotebookMixin, Task):
             static_analysis=static_analysis,
             kernelspec_name=None,
             check_if_kernel_installed=False,
-            extract_up=False,
-            extract_prod=False,
             **kwargs,
         )
         NotebookMixin._validate_parameters_cell(ns, extract_up, extract_prod)

--- a/src/ploomber/tasks/notebook.py
+++ b/src/ploomber/tasks/notebook.py
@@ -273,7 +273,9 @@ class NotebookConverter:
 class NotebookMixin(FileLoaderMixin):
 
     @staticmethod
-    def _validate_parameters_cell(source, extract_up=False, extract_prod=False):
+    def _validate_parameters_cell(source,
+                                  extract_up=False,
+                                  extract_prod=False):
         params_cell, _ = find_cell_with_tag(source._nb_obj_unrendered,
                                             'parameters')
 
@@ -281,7 +283,9 @@ class NotebookMixin(FileLoaderMixin):
             loc = pretty_print.try_relative_path(source.loc)
             # raise MissingParametersCellError(msg)
             # import pdb; pdb.set_trace()
-            notebooksource.add_parameters_cell(source.loc, extract_up, extract_prod)
+            notebooksource.add_parameters_cell(source.loc,
+                                               extract_up,
+                                               extract_prod)
             click.secho(
                 f'Notebook {loc} is missing the parameters cell, '
                 'adding it at the top of the file...',

--- a/tests/cli/test_nb.py
+++ b/tests/cli/test_nb.py
@@ -122,7 +122,9 @@ def test_format_missing_file_in_entry_point(monkeypatch, tmp_directory,
     product: 'some_file.ipynb'""")
     file_name = 'get.py'
     Path('env.yaml').write_text(f"""root: {file_name}""")
-    Path(file_name).write_text("""print("test")""")
+    Path(file_name).write_text("""# %% tags=["parameters"]
+                               \nupstream = None\nproduct = None\n
+                               # %% section \nprint("test")""")
 
     monkeypatch.setattr(sys, 'argv', ['ploomber', 'nb', '--format', 'ipynb'])
     cli.cmd_router()

--- a/tests/sources/test_notebooksource.py
+++ b/tests/sources/test_notebooksource.py
@@ -256,23 +256,21 @@ def test_error_if_source_is_dir_suggest_scaffold(tmp_directory):
     assert 'ploomber scaffold' in str(excinfo.value)
 
 
-def test_error_if_parameters_cell_doesnt_exist():
-    with pytest.raises(SourceInitializationError) as excinfo:
-        NotebookSource(new_nb(fmt='ipynb', add_tag=False), ext_in='ipynb')
-
-    assert 'Notebook does not have a cell tagged "parameters"' in str(
-        excinfo.value)
+def test_warning_if_parameters_cell_doesnt_exist(capsys):
+    NotebookSource(new_nb(fmt='ipynb', add_tag=False), ext_in='ipynb')
+    captured = capsys.readouterr()
+    assert 'Notebook does not have a cell tagged "parameters"' in captured.out
 
 
-def test_error_missing_params_cell_shows_path_if_available(tmp_directory):
+def test_warning_missing_params_cell_shows_path_if_available(tmp_directory,
+                                                             capsys):
     path = Path('nb.ipynb')
     path.write_text(new_nb(fmt='ipynb', add_tag=False))
 
-    with pytest.raises(SourceInitializationError) as excinfo:
-        NotebookSource(path)
-
+    NotebookSource(path)
+    captured = capsys.readouterr()
     assert ('Notebook "nb.ipynb" does not have a cell tagged "parameters"'
-            in str(excinfo.value))
+            in captured.out)
 
 
 def test_nb_str_contains_kernel_info():

--- a/tests/sources/test_notebooksource.py
+++ b/tests/sources/test_notebooksource.py
@@ -256,23 +256,6 @@ def test_error_if_source_is_dir_suggest_scaffold(tmp_directory):
     assert 'ploomber scaffold' in str(excinfo.value)
 
 
-def test_warning_if_parameters_cell_doesnt_exist(capsys):
-    NotebookSource(new_nb(fmt='ipynb', add_tag=False), ext_in='ipynb')
-    captured = capsys.readouterr()
-    assert 'Notebook does not have a cell tagged "parameters"' in captured.out
-
-
-def test_warning_missing_params_cell_shows_path_if_available(tmp_directory,
-                                                             capsys):
-    path = Path('nb.ipynb')
-    path.write_text(new_nb(fmt='ipynb', add_tag=False))
-
-    NotebookSource(path)
-    captured = capsys.readouterr()
-    assert ('Notebook "nb.ipynb" does not have a cell tagged "parameters"'
-            in captured.out)
-
-
 def test_nb_str_contains_kernel_info():
     source = NotebookSource(new_nb(fmt='ipynb'), ext_in='ipynb')
     nb = nbformat.reads(source._nb_str_unrendered,

--- a/tests/tasks/test_notebook.py
+++ b/tests/tasks/test_notebook.py
@@ -1299,38 +1299,37 @@ x/y
     assert "x=1" in captured.out
 
 
-@pytest.mark.parametrize(
-    'code, name, expected_fmt', [
-        ['', 'file.py', 'light'],
-        ['', 'file.py', 'light'],
-        ['', 'file.py', 'light'],
-        [
-            nbformat.writes(nbformat.v4.new_notebook()),
-            'file.ipynb',
-            'ipynb',
-        ],
-        [
-            nbformat.writes(nbformat.v4.new_notebook()),
-            'file.ipynb',
-            'ipynb',
-        ],
-        [
-            '# %%\n1+1\n\n# %%\n2+2',
-            'file.py',
-            'percent',
-        ],
-    ])
-def test_notebook_add_parameters_cell_if_missing(tmp_directory, code,
-                                                 name, expected_fmt,
-                                                 capsys):
+@pytest.mark.parametrize('code, name, expected_fmt', [
+    ['', 'file.py', 'light'],
+    ['', 'file.py', 'light'],
+    ['', 'file.py', 'light'],
+    [
+        nbformat.writes(nbformat.v4.new_notebook()),
+        'file.ipynb',
+        'ipynb',
+    ],
+    [
+        nbformat.writes(nbformat.v4.new_notebook()),
+        'file.ipynb',
+        'ipynb',
+    ],
+    [
+        '# %%\n1+1\n\n# %%\n2+2',
+        'file.py',
+        'percent',
+    ],
+])
+def test_notebook_add_parameters_cell_if_missing(tmp_directory, code, name,
+                                                 expected_fmt, capsys):
     path = Path(name)
     path.write_text(code)
     nb_old = jupytext.read(path)
 
-    NotebookRunner(Path(name),
-                   File('out.html'),
-                   dag=DAG(),
-                   debug_mode='later')
+    dag = DAG()
+
+    NotebookRunner(Path(name), File('out.html'), dag=dag, debug_mode='later')
+
+    dag.render()
 
     # displays adding cell message
     captured = capsys.readouterr()

--- a/tests/tasks/test_notebook.py
+++ b/tests/tasks/test_notebook.py
@@ -1,21 +1,21 @@
 import sys
-from unittest.mock import Mock, ANY
 from pathlib import Path, PurePosixPath
+from unittest.mock import ANY, Mock
 
-import pytest
 import jupytext
-import nbformat
 import nbconvert
+import nbformat
+import pytest
 from debuglater.pydump import debug_dump
 
 from ploomber import DAG, DAGConfigurator
-from ploomber.tasks import NotebookRunner
-from ploomber.products import File
-from ploomber.exceptions import (DAGBuildError, DAGRenderError,
-                                 TaskInitializationError, TaskBuildError)
-from ploomber.tasks import notebook
-from ploomber.executors import Serial
 from ploomber.clients import LocalStorageClient
+from ploomber.exceptions import (DAGBuildError, DAGRenderError, TaskBuildError,
+                                 TaskInitializationError)
+from ploomber.executors import Serial
+from ploomber.products import File
+from ploomber.sources.nb_utils import find_cell_with_tag
+from ploomber.tasks import NotebookRunner, notebook
 
 
 def fake_from_notebook_node(self, nb, resources):
@@ -1297,3 +1297,60 @@ x/y
 
     captured = capsys.readouterr()
     assert "x=1" in captured.out
+
+
+@pytest.mark.parametrize(
+    'code, name, expected_fmt', [
+        ['', 'file.py', 'light'],
+        ['', 'file.py', 'light'],
+        ['', 'file.py', 'light'],
+        [
+            nbformat.writes(nbformat.v4.new_notebook()),
+            'file.ipynb',
+            'ipynb',
+        ],
+        [
+            nbformat.writes(nbformat.v4.new_notebook()),
+            'file.ipynb',
+            'ipynb',
+        ],
+        [
+            '# %%\n1+1\n\n# %%\n2+2',
+            'file.py',
+            'percent',
+        ],
+    ])
+def test_notebook_add_parameters_cell_if_missing(tmp_directory, code,
+                                                 name, expected_fmt,
+                                                 capsys):
+    path = Path(name)
+    path.write_text(code)
+    nb_old = jupytext.read(path)
+
+    NotebookRunner(Path(name),
+                   File('out.html'),
+                   dag=DAG(),
+                   debug_mode='later')
+
+    # displays adding cell message
+    captured = capsys.readouterr()
+    assert ("missing the parameters cell, adding it at the top of the file"
+            in captured.out)
+
+    # checks parameters cell is added
+    nb_new = jupytext.read(path)
+    cell, idx = find_cell_with_tag(nb_new, 'parameters')
+
+    # adds the cell at the top
+    assert idx == 0
+
+    # only adds one cell
+    assert len(nb_old.cells) + 1 == len(nb_new.cells)
+
+    # expected source content
+    assert "add default values for parameters" in cell['source']
+
+    # keeps the same format
+    fmt, _ = (('ipynb', None) if path.suffix == '.ipynb' else
+              jupytext.guess_format(path.read_text(), ext=path.suffix))
+    assert fmt == expected_fmt

--- a/tests/tasks/test_scriptrunner.py
+++ b/tests/tasks/test_scriptrunner.py
@@ -3,13 +3,16 @@ Tests for ScriptRunner
 """
 from pathlib import Path
 
+import jupytext
+import nbformat
 import pytest
 
 from ploomber import DAG
+from ploomber.exceptions import DAGBuildError
+from ploomber.products import File
+from ploomber.sources.nb_utils import find_cell_with_tag
 from ploomber.tasks import ScriptRunner
 from ploomber.tasks.notebook import NotebookMixin
-from ploomber.products import File
-from ploomber.exceptions import DAGBuildError
 
 
 @pytest.fixture
@@ -109,3 +112,59 @@ def test_execute_script_with_unknown_langguage(tmp_env):
 
     assert 'ScriptRunner only works with Python and R scripts' in str(
         excinfo.value)
+
+
+@pytest.mark.parametrize(
+    'code, name, expected_fmt', [
+        ['', 'file.py', 'light'],
+        ['', 'file.py', 'light'],
+        ['', 'file.py', 'light'],
+        [
+            nbformat.writes(nbformat.v4.new_notebook()),
+            'file.ipynb',
+            'ipynb',
+        ],
+        [
+            nbformat.writes(nbformat.v4.new_notebook()),
+            'file.ipynb',
+            'ipynb',
+        ],
+        [
+            '# %%\n1+1\n\n# %%\n2+2',
+            'file.py',
+            'percent',
+        ],
+    ])
+def test_execute_script_add_parameters_cell_if_missing(tmp_directory, code,
+                                                       name, expected_fmt,
+                                                       capsys):
+    path = Path(name)
+    path.write_text(code)
+    nb_old = jupytext.read(path)
+
+    ScriptRunner(Path(name),
+                 File('out.html'),
+                 dag=DAG())
+
+    # displays adding cell message
+    captured = capsys.readouterr()
+    assert ("missing the parameters cell, adding it at the top of the file"
+            in captured.out)
+
+    # checks parameters cell is added
+    nb_new = jupytext.read(path)
+    cell, idx = find_cell_with_tag(nb_new, 'parameters')
+
+    # adds the cell at the top
+    assert idx == 0
+
+    # only adds one cell
+    assert len(nb_old.cells) + 1 == len(nb_new.cells)
+
+    # expected source content
+    assert "add default values for parameters" in cell['source']
+
+    # keeps the same format
+    fmt, _ = (('ipynb', None) if path.suffix == '.ipynb' else
+              jupytext.guess_format(path.read_text(), ext=path.suffix))
+    assert fmt == expected_fmt


### PR DESCRIPTION
## Describe your changes
* Change exception to warnings for missing cells in `_post_init_validation`
* Update exception tests `test_error_if_parameters_cell_doesnt_exist` and `test_error_missing_params_cell_shows_path_if_available` to check warnings instead
* Create a method `_validate_parameters_cell` in the class NotebookMixin in `src/ploomber/tasks/notebook.py` to check and add parameter cells if missing

## Issue ticket number and link
Closes #950

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

