### PR TITLE
added suffix flag for automatically add number suffix to products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.21.1dev
 
+* Adds `grid_number_suffix` flag in pipeline.yaml to prevent naming conflicts of products ([#973](https://github.com/ploomber/ploomber/issues/973))
+
 ## 0.21 (2022-08-22)
 
 * Adds `ploomber.micro` module for writing micro pipelines

--- a/doc/api/spec.rst
+++ b/doc/api/spec.rst
@@ -954,6 +954,32 @@ for example, it will store the random forest with ``n_estimators=5``, and
 uses square brackets to differentiate them from regular placeholders when
 using an ``env.yaml`` file.
 
+In the latest version, we have introduced a speical flag called `grid_number_suffix`.
+The purpose of this flag is to prevent naming conflicts of our outputs. It is default 
+to be turned off. For example, in above example, since we have two placeholders for 
+two params in the grid, all products will have different names, thus it works properly.
+
+Consider this case: 
+
+.. code-block:: yaml
+    :class: text-editor
+    :name: grid-example-2-yaml
+
+    tasks:
+      - source: random-forest.py
+        name: random-forest-
+        product: 'n_estimators.html'
+        grid:
+            n_estimators: [5, 10, 20]
+            criterion: [gini, entropy]
+
+All products will have the same `n_estimators.html` name and that is a problem. Such pipeline.yaml
+will output error to indicate either we can add `grid_number_suffix: True`, or we
+can give proper placeholders like the other case. If we turned on the flag, the output files will be
+something like `n_estimators.html-0`, `n_estimators.html-1`, etc. Be advised, not giving enough 
+placeholders for grid params will also cause ploomber to output error.
+
+
 **Templating name tasks**
 
 Similarly, you can also customize task names (**Added in version 0.19.8**):

--- a/doc/api/spec.rst
+++ b/doc/api/spec.rst
@@ -954,7 +954,7 @@ for example, it will store the random forest with ``n_estimators=5``, and
 uses square brackets to differentiate them from regular placeholders when
 using an ``env.yaml`` file.
 
-In the latest version, we have introduced a special flag called `grid_number_suffix`.
+After version 0.21.1, we have introduced a special flag called `grid_number_suffix`.
 The purpose of this flag is to prevent naming conflicts of our outputs. It is default 
 to be turned off. For example, in above example, since we have two placeholders for 
 two params in the grid, all products will have different names, thus it works properly.

--- a/doc/api/spec.rst
+++ b/doc/api/spec.rst
@@ -954,7 +954,7 @@ for example, it will store the random forest with ``n_estimators=5``, and
 uses square brackets to differentiate them from regular placeholders when
 using an ``env.yaml`` file.
 
-In the latest version, we have introduced a speical flag called `grid_number_suffix`.
+In the latest version, we have introduced a special flag called `grid_number_suffix`.
 The purpose of this flag is to prevent naming conflicts of our outputs. It is default 
 to be turned off. For example, in above example, since we have two placeholders for 
 two params in the grid, all products will have different names, thus it works properly.

--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -299,6 +299,7 @@ class TaskSpec(MutableMapping):
 
         if 'grid' in data:
             data_source_ = data["source"]
+            grid_number_suffix = data.pop('grid_number_suffix', False)
             data_source = str(data_source_ if not hasattr(
                 data_source_, '__name__') else data_source_.__name__)
 
@@ -350,6 +351,7 @@ class TaskSpec(MutableMapping):
                                        on_render=on_render,
                                        on_finish=on_finish,
                                        on_failure=on_failure,
+                                       grid_number_suffix=grid_number_suffix,
                                        params=params,
                                        **name_arg), upstream
         else:

--- a/src/ploomber/tasks/taskgroup.py
+++ b/src/ploomber/tasks/taskgroup.py
@@ -274,7 +274,7 @@ class TaskGroup:
 
             .. versionadded:: 0.21.1
                 Added grid_number_suffix flag
-        
+
         """
 
         if (

--- a/src/ploomber/tasks/taskgroup.py
+++ b/src/ploomber/tasks/taskgroup.py
@@ -244,6 +244,7 @@ class TaskGroup:
                   task_kwargs,
                   dag,
                   grid,
+                  grid_number_suffix,
                   name=None,
                   namer=None,
                   resolve_relative_to=None,
@@ -269,6 +270,21 @@ class TaskGroup:
         -----
         All parameters, except for grid are the same as in .from_params
         """
+
+        if (
+            len(grid) != product_primitive.count('[[')
+            and not grid_number_suffix
+        ):
+            raise NameError('Unable to resolove pipeline. '
+                            'Multiple tasks may contain output '
+                            'files with identical names. \n'
+                            'You can change the product names, '
+                            'or add additional [[placeholders]] '
+                            'to uniquely identify these products or '
+                            'set `grid_number_suffix: true` '
+                            'to automatically add numbered suffixes '
+                            'to these products to make them unique.')
+
         params_array = ParamGrid(grid, params=params).product()
         return cls.from_params(task_class=task_class,
                                product_class=product_class,

--- a/src/ploomber/tasks/taskgroup.py
+++ b/src/ploomber/tasks/taskgroup.py
@@ -269,6 +269,12 @@ class TaskGroup:
         Notes
         -----
         All parameters, except for grid are the same as in .from_params
+
+        .. collapse :: change log
+
+            .. versionadded:: 0.21.1
+                Added grid_number_suffix flag
+        
         """
 
         if (

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -449,6 +449,7 @@ def test_file_spec_resolves_sources_location(tmp_nbs):
                 'source': 'task.py',
                 'product': 'out.ipynb',
                 'name': 'task-',
+                'grid_number_suffix': True,
                 'grid': {
                     'param': [1, 2]
                 }
@@ -518,6 +519,7 @@ upstream = None
                 'source': 'task.py',
                 'product': 'out.ipynb',
                 'name': 'task-',
+                'grid_number_suffix': True,
                 'grid': {
                     'param': [1, 2]
                 }
@@ -1617,6 +1619,7 @@ _spec_upstream_extract = {
         'source': 'upstream.py',
         'name': 'upstream-',
         'product': 'upstream.ipynb',
+        'grid_number_suffix': True,
         'grid': {
             'param': [1, 2]
         }
@@ -1634,6 +1637,7 @@ _spec_upstream_manual = {
         'source': 'upstream.py',
         'name': 'upstream-',
         'product': 'upstream.ipynb',
+        'grid_number_suffix': True,
         'grid': {
             'param': [1, 2]
         }
@@ -1681,6 +1685,7 @@ _spec_callables = {
         'source': 'sample_source_callables.upstream',
         'name': 'upstream-',
         'product': 'upstream.txt',
+        'grid_number_suffix': True,
         'grid': {
             'param': [1, 2]
         }
@@ -1697,6 +1702,7 @@ _spec_callables_unserializer = {
         'source': 'sample_source_callables.upstream',
         'name': 'upstream-',
         'product': 'upstream.txt',
+        'grid_number_suffix': True,
         'grid': {
             'param': [1, 2]
         }

--- a/tests/spec/test_taskspec.py
+++ b/tests/spec/test_taskspec.py
@@ -479,6 +479,7 @@ def grid_spec():
         'source': 'my_tasks_flat.raw.function',
         'name': 'function-',
         'product': 'some_file.txt',
+        'grid_number_suffix': True,
         'grid': {
             'a': [1, 2],
             'b': [3, 4]
@@ -509,6 +510,7 @@ def test_grid_with_hook(backup_spec_with_functions_flat, tmp_imports):
         'source': 'my_tasks_flat.raw.function',
         'name': 'function-',
         'product': 'some_file.txt',
+        'grid_number_suffix': True,
         'grid': {
             'a': [1, 2],
             'b': [3, 4]
@@ -536,6 +538,7 @@ def test_grid_with_hook_lazy_import(backup_spec_with_functions_flat,
         'source': 'my_tasks_flat.raw.function',
         'name': 'function-',
         'product': 'some_file.txt',
+        'grid_number_suffix': True,
         'grid': {
             'a': [1, 2],
             'b': [3, 4]
@@ -756,6 +759,7 @@ def range_(n):
             'source': 'my_module.fn',
             'product': 'report.ipynb',
             'name': 'fn-',
+            'grid_number_suffix': True,
             'grid': grid,
         },
         Meta.default_meta(),
@@ -802,6 +806,7 @@ def crash():
             'source': 'my_module.fn',
             'product': 'report.ipynb',
             'name': 'fn-',
+            'grid_number_suffix': True,
             'grid': grid,
         },
         Meta.default_meta(),

--- a/tests/tasks/test_taskgroup.py
+++ b/tests/tasks/test_taskgroup.py
@@ -181,6 +181,7 @@ def test_from_grid():
                                 },
                                 dag,
                                 name='task_group',
+                                grid_number_suffix=True,
                                 grid={
                                     'a': [1, 2],
                                     'b': [3, 4]
@@ -198,6 +199,7 @@ def test_from_grid_with_params():
                         },
                         dag,
                         name='task_group',
+                        grid_number_suffix=True,
                         grid={
                             'a': [1, 2],
                             'b': [3, 4]
@@ -227,6 +229,7 @@ def test_from_grid_with_hook(hook_name):
                                 },
                                 dag,
                                 name='task_group',
+                                grid_number_suffix=True,
                                 grid={
                                     'a': [1, 2],
                                     'b': [3, 4]
@@ -246,6 +249,7 @@ def test_from_grid_resolve_relative_to():
                         },
                         dag,
                         name='task_group',
+                        grid_number_suffix=True,
                         grid={
                             'a': [1, 2],
                             'b': [3, 4]

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -553,6 +553,7 @@ param = None
             'source': 'my-task.py',
             'name': 'my-task-',
             'product': 'my-task.ipynb',
+            'grid_number_suffix': True,
             'grid': {
                 'param': [1, 2]
             }


### PR DESCRIPTION
## Describe your changes
User now can add grid_number_suffix to pipeline.yaml
With it on we automatically add number suffix to outputs to prevent same names;
With it off, we print error if output contain same names, user need to turn it on or have proper amount of placeholders.

Doc added.

## Issue ticket number and link
Closes #973 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

