### PR TITLE
add tabs for cli/python api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ projects-tmp/
 examples/pipeline/results/
 ploomber-venv
 
+# ignore docs generated from ploomber/projects
+doc/*/**/*.md
 doc/**/*.ipynb
 .pytest_cache/
 .vscode/

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -128,3 +128,41 @@ Read more about additional options to embed code blocks in `.rst` files by visit
 
 Login to [algolia crawler](https://crawler.algolia.com). Select ploomber in the crawlers section. Select Editor from the side bar. This allows you to make edits to the config file. To add code snippets to the indexing, I appended  `pre` to the array assigned to `content`, which is under the `recordProps` property. This is because  code blocks are within a `<pre>` tag in HTML. After making edits, you can use the URL Tester to test. Click save when you are ready. After clicking save, exit the text editor and restart the crawler. After the crawler finishes restarting, Docsearch should be updated on the site. 
 
+
+#### Ploomber Example
+
+To reflect the users' option of using Ploomber's CLI tool or the Python API, we
+want the documentation to include examples with both. To do this we can use
+the custom sphinx directive `ploomber-example` when writing code snippets:
+
+rst:
+```rst
+.. ploomber-example::
+
+   .. example-python::
+
+       .. code-block:: python
+          :class: text-editor
+
+          dag.build()
+
+   .. example-cli::
+
+       .. code-block:: Bash
+          :class: text-editor
+          :name: task-bash
+
+          ploomber build --force
+```
+
+rendered:
+![image](https://user-images.githubusercontent.com/31556469/187514196-fad945fd-dd58-4f95-b6cb-8538d3bc03bc.png)
+![image](https://user-images.githubusercontent.com/31556469/187514250-34b1a356-16fe-4e83-937b-d4a0153710bc.png)
+
+
+Additionally, when writing documentation, we must consider that the Python
+API is stateful, while the CLI is not.
+
+For example, if a user runs `dag.build()`, modifies a task's source and runs
+`dag.build()` again - the source code change wont be detected, this is because
+once we load the DAG, we don't check status changes.

--- a/doc/_ext/ploomber_example.py
+++ b/doc/_ext/ploomber_example.py
@@ -1,0 +1,92 @@
+from docutils import nodes
+from docutils.statemachine import ViewList
+from sphinx_tabs.tabs import TabsDirective, GroupTabDirective
+
+
+class PloomberExampleCliDirective(GroupTabDirective):
+
+    has_content = True
+
+    def run(self):
+
+        self.assert_has_content()
+
+        new_content = ViewList([
+            'CLI',
+            '',
+        ])
+
+        new_content.append(self.content)
+
+        self.content = new_content
+
+        node = super().run()
+
+        return node
+
+
+class PloomberExamplePythonDirective(GroupTabDirective):
+
+    has_content = True
+
+    def run(self):
+
+        self.assert_has_content()
+
+        # ploomber example config
+        # found with python -m sphinx.ext.intersphinx _build/html/objects.inv
+        ploomber_example_prepare_info_path = '../user-guide'\
+            '/using-python-api.html'
+
+        ref_node = nodes.reference(
+            '',
+            '',
+            internal=True,
+            # refname=app.config["ploomber_example_prepare_info_path"])
+            refuri=ploomber_example_prepare_info_path)
+
+        inner_node = nodes.emphasis("here.", "here.")
+
+        ref_node.append(inner_node)
+
+        note_node = nodes.note()
+
+        warning_text_node = nodes.paragraph(
+            text='Unlike the command line interface, the Ploomber Python '
+            'API requires preparation before each command. Find more '
+            'information ')
+
+        warning_text_node += ref_node
+
+        note_node.append(warning_text_node)
+
+        new_content = ViewList([
+            'Python',
+            '',
+        ])
+
+        new_content.append(self.content)
+
+        self.content = new_content
+
+        tab_node = super().run()[0]
+
+        # prepend
+        tab_node.insert(0, note_node)
+
+        return [tab_node]
+
+
+def setup(app):
+    app.add_config_value('ploomber_example_prepare_info_path',
+                         'unconfigured prepare guide path', 'html')
+
+    app.add_directive("ploomber-example", TabsDirective)
+    app.add_directive("example-python", PloomberExamplePythonDirective)
+    app.add_directive("example-cli", PloomberExampleCliDirective)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,6 +15,7 @@ import sys
 from ploomber import __version__
 
 sys.path.insert(0, os.path.abspath('.'))
+sys.path.append(os.path.abspath('./_ext'))
 import hooks  # noqa
 
 # -- Project information -----------------------------------------------------
@@ -31,12 +32,9 @@ release = version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.autosectionlabel',
-    'nbsphinx',
-    'sphinx_toolbox.collapse',
+    'sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinx.ext.autosummary',
+    'sphinx.ext.autosectionlabel', 'nbsphinx', 'sphinx_toolbox.collapse',
+    'sphinx_tabs.tabs', 'myst_parser', 'ploomber_example'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -34,5 +34,7 @@ dependencies:
     - jupytext
     - ipywidgets
 
+    - myst-parser
+
     # install ploomber
     - -e ..

--- a/doc/hooks.py
+++ b/doc/hooks.py
@@ -36,9 +36,9 @@ def config_init(app, config):
 
     # move README.ipynb files to their corresponding location in the docs
     for path, target_dir in directories.items():
-        src = Path(projects, path, 'README.ipynb')
+        src = Path(projects, path, 'README.md')
         name = Path(path).name
-        dst = Path(target_dir, f'{name}.ipynb')
+        dst = Path(target_dir, f'{name}.md')
         print(f'Copying {src} to {dst}')
         shutil.copy(src, dst)
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,3 +15,5 @@ papermill
 jupytext
 ipywidgets
 sphinx-toolbox
+sphinx-tabs
+myst-parser

--- a/doc/user-guide/index.rst
+++ b/doc/user-guide/index.rst
@@ -28,3 +28,4 @@ User Guide
     r-support
     faq_index
     spec-vs-python
+    using-python-api

--- a/doc/user-guide/using-python-api.rst
+++ b/doc/user-guide/using-python-api.rst
@@ -1,0 +1,37 @@
+.. _Using-Python-In-Docs
+Using the Python API in the docs
+===============================
+
+Unlike the command line interface, the Ploomber Python
+API requires this preparation before each command:
+
+.. code-block:: python
+    :class: text-editor
+    :name: task-py
+
+    from ploomber.spec import DAGSpec
+    dag = DAGSpec.find().to_dag()
+
+
+For example, in building:
+
+.. code-block:: python
+    :class: text-editor
+    :name: task-py
+
+    # prepare
+    from ploomber.spec import DAGSpec
+    dag = DAGSpec.find().to_dag()
+
+    # build
+    dag.build()
+
+is equivalent to:
+
+.. code-block:: console
+
+    ploomber build
+
+For brevity the documentation does not include the prepare command in every code
+snippet however it is necessary before every python command for proper
+functionality


### PR DESCRIPTION
## Describe your changes

here is an example:

myst
````md
~~~{ploomber-example}
  ```{example-python}
      ```sh magic_args="--no-raise-error"
      ploomber build --force
      ```
   ```
   ```{example-cli}
      ```sh magic_args="--no-raise-error"
      ploomber build --force
     ```
   ``` 
~~~
````

equivalent to rst:
```rst
.. ploomber-example::

   .. example-python::

       .. code-block:: Bash
          :class: text-editor
          :name: task-bash

          ploomber build --force
   .. example-cli::

       .. code-block:: bash
          :class: text-editor
          :name: task-bash

          ploomber build --force

```

rendered:
![image](https://user-images.githubusercontent.com/31556469/186720020-3dbe2cb2-a0be-4e18-8f5d-879932e3ed50.png)
![image](https://user-images.githubusercontent.com/31556469/186717565-58332e57-dcad-4014-a71f-8604cb691069.png)

As for Python API statefulness I think we just have to keep that in mind when writing the docs.

## Issue ticket number and link
Closes #938

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

