### PR TITLE
Dag gracefully exit doc

### DIFF
--- a/src/ploomber/executors/parallel.py
+++ b/src/ploomber/executors/parallel.py
@@ -104,7 +104,6 @@ class Parallel(Executor):
     >>> from ploomber.exceptions import DAGBuildEarlyStop
     >>> # A PythonCallable function that raises DAGBuildEarlyStop
     >>> def early_stop_root(product):
-    ...     Path(product).touch()
     ...     raise DAGBuildEarlyStop('Ending gracefully')
 
     >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.

--- a/src/ploomber/executors/parallel.py
+++ b/src/ploomber/executors/parallel.py
@@ -110,7 +110,7 @@ class Parallel(Executor):
     >>> def touch_root(fn):
     ...     Path(str(fn)).touch()
 
-    >>> # Use the task-level hook "on_finish" to exit DAG gracefully.
+    >>> # Use task-level hook "on_finish" to exit DAG gracefully.
     ... dag = DAG(executor='parallel')
     ... t = NotebookRunner(touch_root, File('file.txt'), dag)
     ... t.on_finish = early_stop

--- a/src/ploomber/executors/parallel.py
+++ b/src/ploomber/executors/parallel.py
@@ -35,6 +35,7 @@ class TaskBuildWrapper:
     here and return it so at the end of the DAG execution, a message with the
     traceback can be printed
     """
+
     def __init__(self, task):
         self.task = task
 
@@ -91,27 +92,29 @@ class Parallel(Executor):
 
     DAG can exit gracefully on function tasks (PythonCallable):
 
+    >>> from ploomber.products import File
+    >>> from ploomber.tasks import PythonCallable
     >>> # A PythonCallable function that raises DAGBuildEarlyStop
     >>> def early_stop_root(product):
-    >>>     raise DAGBuildEarlyStop('Ending gracefully')
+    ...     raise DAGBuildEarlyStop('Ending gracefully')
 
     >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.
     >>> dag = DAG(executor='parallel') # use with default values
-    >>> PythonCallable(early_stop_root, File('file.txt'), dag)
-    >>> dag.build()  # This will return None
+    ... PythonCallable(early_stop_root, File('file.txt'), dag)
+    ... dag.build()
 
 
     DAG can also exit gracefully on notebook tasks:
-
-    >>> # A function that calls on a task-level function fn
+    >>> from pathlib import Path
+    >>> from ploomber.tasks import NotebookRunner
     >>> def touch_root(fn):
-    >>>     Path(str(fn)).touch()
+    ...     Path(str(fn)).touch()
 
     >>> # Use the task-level hook "on_finish" to exit DAG gracefully.
     >>> dag = DAG(executor='parallel') # use with default values
-    >>> t = PythonCallable(touch_root, File('file.txt'), dag)
-    >>> t.on_finish = early_stop
-    >>> dag.build()  # This will return None
+    ... t = NotebookRunner(touch_root, File('file.txt'), dag)
+    ... t.on_finish = early_stop
+    ... dag.build()
 
     Notes
     -----

--- a/src/ploomber/executors/parallel.py
+++ b/src/ploomber/executors/parallel.py
@@ -99,7 +99,7 @@ class Parallel(Executor):
     ...     raise DAGBuildEarlyStop('Ending gracefully')
 
     >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.
-    >>> dag = DAG(executor='parallel') # use with default values
+    >>> dag = DAG(executor='parallel')
     ... PythonCallable(early_stop_root, File('file.txt'), dag)
     ... dag.build()
 
@@ -111,7 +111,7 @@ class Parallel(Executor):
     ...     Path(str(fn)).touch()
 
     >>> # Use the task-level hook "on_finish" to exit DAG gracefully.
-    >>> dag = DAG(executor='parallel') # use with default values
+    >>> dag = DAG(executor='parallel')
     ... t = NotebookRunner(touch_root, File('file.txt'), dag)
     ... t.on_finish = early_stop
     ... dag.build()

--- a/src/ploomber/executors/parallel.py
+++ b/src/ploomber/executors/parallel.py
@@ -113,7 +113,7 @@ class Parallel(Executor):
 
 
     DAG can also exit gracefully on notebook tasks:
-    
+
     >>> from pathlib import Path
     >>> from ploomber.tasks import NotebookRunner
     >>> from ploomber.products import File

--- a/src/ploomber/executors/parallel.py
+++ b/src/ploomber/executors/parallel.py
@@ -99,7 +99,7 @@ class Parallel(Executor):
     ...     raise DAGBuildEarlyStop('Ending gracefully')
 
     >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.
-    >>> dag = DAG(executor='parallel')
+    ... dag = DAG(executor='parallel')
     ... PythonCallable(early_stop_root, File('file.txt'), dag)
     ... dag.build()
 
@@ -111,7 +111,7 @@ class Parallel(Executor):
     ...     Path(str(fn)).touch()
 
     >>> # Use the task-level hook "on_finish" to exit DAG gracefully.
-    >>> dag = DAG(executor='parallel')
+    ... dag = DAG(executor='parallel')
     ... t = NotebookRunner(touch_root, File('file.txt'), dag)
     ... t.on_finish = early_stop
     ... dag.build()

--- a/src/ploomber/executors/parallel.py
+++ b/src/ploomber/executors/parallel.py
@@ -90,6 +90,30 @@ class Parallel(Executor):
     >>> dag = DAG(executor=Parallel(processes=2)) # customize
 
 
+    DAG can exit gracefully on function tasks (PythonCallable):
+
+    >>> # A PythonCallable function that raises DAGBuildEarlyStop
+    >>> def early_stop_root(product):
+    >>>     raise DAGBuildEarlyStop('Ending gracefully')
+
+    >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.
+    >>> dag = DAG(executor='parallel') # use with default values
+    >>> PythonCallable(early_stop_root, File('file.txt'), dag)
+    >>> dag.build()  # This will return None
+
+
+    DAG can also exit gracefully on notebook tasks:
+
+    >>> # A function that calls on a task-level function fn
+    >>> def touch_root(fn):
+    >>>     Path(str(fn)).touch()
+
+    >>> # Use the task-level hook "on_finish" to exit DAG gracefully.
+    >>> dag = DAG(executor='parallel') # use with default values
+    >>> t = PythonCallable(touch_root, File('file.txt'), dag)
+    >>> t.on_finish = early_stop
+    >>> dag.build()  # This will return None
+
     Notes
     -----
     If any task crashes, downstream tasks execution is aborted, building

--- a/src/ploomber/executors/parallel.py
+++ b/src/ploomber/executors/parallel.py
@@ -35,7 +35,6 @@ class TaskBuildWrapper:
     here and return it so at the end of the DAG execution, a message with the
     traceback can be printed
     """
-
     def __init__(self, task):
         self.task = task
 

--- a/src/ploomber/executors/serial.py
+++ b/src/ploomber/executors/serial.py
@@ -82,7 +82,7 @@ class Serial(Executor):
 
 
     DAG can also exit gracefully on notebook tasks:
-    
+
     >>> from pathlib import Path
     >>> from ploomber.tasks import NotebookRunner
     >>> from ploomber.products import File
@@ -107,7 +107,7 @@ class Serial(Executor):
                  catch_warnings=True):
         self._logger = logging.getLogger(__name__)
         self._build_in_subprocess = build_in_subprocess
-        self ._catch_exceptions = catch_exceptions
+        self._catch_exceptions = catch_exceptions
         self._catch_warnings = catch_warnings
 
     def __repr__(self):

--- a/src/ploomber/executors/serial.py
+++ b/src/ploomber/executors/serial.py
@@ -73,7 +73,6 @@ class Serial(Executor):
     >>> from ploomber.exceptions import DAGBuildEarlyStop
     >>> # A PythonCallable function that raises DAGBuildEarlyStop
     >>> def early_stop_root(product):
-    ...     Path(product).touch()
     ...     raise DAGBuildEarlyStop('Ending gracefully')
 
     >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.

--- a/src/ploomber/executors/serial.py
+++ b/src/ploomber/executors/serial.py
@@ -68,7 +68,7 @@ class Serial(Executor):
     ...     raise DAGBuildEarlyStop('Ending gracefully')
 
     >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.
-    >>> dag = DAG(executor='parallel') # use with default values
+    >>> dag = DAG(executor='parallel')
     ... PythonCallable(early_stop_root, File('file.txt'), dag)
     ... dag.build()
 
@@ -80,7 +80,7 @@ class Serial(Executor):
     ...     Path(str(fn)).touch()
 
     >>> # Use the task-level hook "on_finish" to exit DAG gracefully.
-    >>> dag = DAG(executor='parallel') # use with default values
+    >>> dag = DAG(executor='parallel')
     ... t = NotebookRunner(touch_root, File('file.txt'), dag)
     ... t.on_finish = early_stop
     ... dag.build()

--- a/src/ploomber/executors/serial.py
+++ b/src/ploomber/executors/serial.py
@@ -183,6 +183,19 @@ class LazyFunction:
 
 
 def catch_warnings(fn, warnings_all):
+    """
+    Catch all warnings on the current task (except DeprecationWarning) 
+    and append them to warnings_all. Runs if the parameter catch_warnings is true.
+
+    Parameters
+    ----------
+    fn : function
+        A LazyFunction that automatically calls catch_warnings, with parameters 
+        from the main function (warnings_all) and the current scheduled task.
+
+    warnings_all: BuildWarningsCollector object
+        Collects all warnings.
+    """
     # TODO: we need a try catch in case fn() raises an exception
     with warnings.catch_warnings(record=True) as warnings_current:
         warnings.simplefilter("ignore", DeprecationWarning)
@@ -197,6 +210,19 @@ def catch_warnings(fn, warnings_all):
 
 
 def catch_exceptions(fn, exceptions_all):
+    """
+    If there is an exception, log it and append it to warnings_all. Runs if 
+    the parameter catch_exceptions is true.
+
+    Parameters
+    ----------
+    fn : function
+        A LazyFunction that automatically calls catch_exceptions, with parameters 
+        from the main function (exceptions_all) and the current scheduled task.
+
+    exceptions_all: BuildExceptionsCollector object
+        Collects all exceptions.
+    """
     logger = logging.getLogger(__name__)
     # NOTE: we are individually catching exceptions
     # (see build_in_current_process and build_in_subprocess), would it be
@@ -219,17 +245,59 @@ def catch_exceptions(fn, exceptions_all):
 
 
 def pass_exceptions(fn):
+    """
+    Pass all exceptions for the current task and nothing. Runs if both parameters 
+    catch_exceptions and catch_warnings are false.
+
+    Parameters
+    ----------
+    fn : function
+        A LazyFunction that automatically calls pass_exceptions on the 
+        current scheduled task.
+    """
     # should i still check here for DAGBuildEarlyStop? is it worth
     # for returning accurate task status?
     fn()
 
 
 def build_in_current_process(task, build_kwargs, reports_all):
+    """
+    Execute the current task in the current process. Runs if the parameter 
+    build_in_subprocess is false.
+
+    Parameters
+    ----------
+    task : DAG object
+        The current task.
+
+    build_kwargs: dict
+        Contains bool catch_exceptions and bool catch_warnings, checks whether to 
+        catch exceptions and warnings on the current task.
+
+    reports_all: list
+        Collects the build report when executing the current DAG.
+    """
     report, meta = task._build(**build_kwargs)
     reports_all.append(report)
 
 
 def build_in_subprocess(task, build_kwargs, reports_all):
+    """
+    Execute the current task in a subprocess. Runs if the parameter 
+    build_in_subprocess is true.
+    
+    Parameters
+    ----------
+    task : DAG object
+        The current task.
+
+    build_kwargs: dict
+        Contains bool catch_exceptions and bool catch_warnings, checks whether to 
+        catch exceptions and warnings on the current task.
+
+    reports_all: list
+        Collects the build report when executing the current DAG.
+    """
     if callable(task.source.primitive):
 
         try:

--- a/src/ploomber/executors/serial.py
+++ b/src/ploomber/executors/serial.py
@@ -58,6 +58,31 @@ class Serial(Executor):
     >>> dag = DAG(executor='parallel') # use with default values
     >>> dag = DAG(executor=Serial(build_in_subprocess=False)) # customize
 
+
+    DAG can exit gracefully on function tasks (PythonCallable):
+
+    >>> # A PythonCallable function that raises DAGBuildEarlyStop
+    >>> def early_stop_root(product):
+    >>>     raise DAGBuildEarlyStop('Ending gracefully')
+
+    >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.
+    >>> dag = DAG(executor='parallel') # use with default values
+    >>> PythonCallable(early_stop_root, File('file.txt'), dag)
+    >>> dag.build()  # This will return None
+
+
+    DAG can also exit gracefully on notebook tasks:
+
+    >>> # A function that calls on a task-level function fn
+    >>> def touch_root(fn):
+    >>>     Path(str(fn)).touch()
+
+    >>> # Use the task-level hook "on_finish" to exit DAG gracefully.
+    >>> dag = DAG(executor='parallel') # use with default values
+    >>> t = PythonCallable(touch_root, File('file.txt'), dag)
+    >>> t.on_finish = early_stop
+    >>> dag.build()  # This will return None
+
     See Also
     --------
     ploomber.executors.Parallel :

--- a/src/ploomber/executors/serial.py
+++ b/src/ploomber/executors/serial.py
@@ -68,7 +68,7 @@ class Serial(Executor):
     ...     raise DAGBuildEarlyStop('Ending gracefully')
 
     >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.
-    >>> dag = DAG(executor='parallel')
+    ... dag = DAG(executor='parallel')
     ... PythonCallable(early_stop_root, File('file.txt'), dag)
     ... dag.build()
 
@@ -80,7 +80,7 @@ class Serial(Executor):
     ...     Path(str(fn)).touch()
 
     >>> # Use the task-level hook "on_finish" to exit DAG gracefully.
-    >>> dag = DAG(executor='parallel')
+    ... dag = DAG(executor='parallel')
     ... t = NotebookRunner(touch_root, File('file.txt'), dag)
     ... t.on_finish = early_stop
     ... dag.build()

--- a/src/ploomber/executors/serial.py
+++ b/src/ploomber/executors/serial.py
@@ -210,7 +210,8 @@ class LazyFunction:
 def catch_warnings(fn, warnings_all):
     """
     Catch all warnings on the current task (except DeprecationWarning) 
-    and append them to warnings_all. Runs if the parameter catch_warnings is true.
+    and append them to warnings_all. Runs if the parameter catch_warnings
+    is true.
 
     Parameters
     ----------
@@ -242,8 +243,9 @@ def catch_exceptions(fn, exceptions_all):
     Parameters
     ----------
     fn : function
-        A LazyFunction that automatically calls catch_exceptions, with parameters 
-        from the main function (exceptions_all) and the current scheduled task.
+        A LazyFunction that automatically calls catch_exceptions, with 
+        parameters from the main function (exceptions_all) and the 
+        current scheduled task.
 
     exceptions_all: BuildExceptionsCollector object
         Collects all exceptions.
@@ -271,8 +273,8 @@ def catch_exceptions(fn, exceptions_all):
 
 def pass_exceptions(fn):
     """
-    Pass all exceptions for the current task and nothing. Runs if both parameters 
-    catch_exceptions and catch_warnings are false.
+    Pass all exceptions for the current task and nothing. Runs if 
+    both parameters catch_exceptions and catch_warnings are false.
 
     Parameters
     ----------
@@ -296,8 +298,8 @@ def build_in_current_process(task, build_kwargs, reports_all):
         The current task.
 
     build_kwargs: dict
-        Contains bool catch_exceptions and bool catch_warnings, checks whether to 
-        catch exceptions and warnings on the current task.
+        Contains bool catch_exceptions and bool catch_warnings, checks 
+        whether to catch exceptions and warnings on the current task.
 
     reports_all: list
         Collects the build report when executing the current DAG.
@@ -310,15 +312,15 @@ def build_in_subprocess(task, build_kwargs, reports_all):
     """
     Execute the current task in a subprocess. Runs if the parameter 
     build_in_subprocess is true.
-    
+
     Parameters
     ----------
     task : DAG object
         The current task.
 
     build_kwargs: dict
-        Contains bool catch_exceptions and bool catch_warnings, checks whether to 
-        catch exceptions and warnings on the current task.
+        Contains bool catch_exceptions and bool catch_warnings, checks 
+        whether to catch exceptions and warnings on the current task.
 
     reports_all: list
         Collects the build report when executing the current DAG.

--- a/src/ploomber/executors/serial.py
+++ b/src/ploomber/executors/serial.py
@@ -61,33 +61,36 @@ class Serial(Executor):
 
     DAG can exit gracefully on function tasks (PythonCallable):
 
+    >>> from ploomber.products import File
+    >>> from ploomber.tasks import PythonCallable
     >>> # A PythonCallable function that raises DAGBuildEarlyStop
     >>> def early_stop_root(product):
-    >>>     raise DAGBuildEarlyStop('Ending gracefully')
+    ...     raise DAGBuildEarlyStop('Ending gracefully')
 
     >>> # Since DAGBuildEarlyStop is raised, DAG will exit gracefully.
     >>> dag = DAG(executor='parallel') # use with default values
-    >>> PythonCallable(early_stop_root, File('file.txt'), dag)
-    >>> dag.build()  # This will return None
+    ... PythonCallable(early_stop_root, File('file.txt'), dag)
+    ... dag.build()
 
 
     DAG can also exit gracefully on notebook tasks:
-
-    >>> # A function that calls on a task-level function fn
+    >>> from pathlib import Path
+    >>> from ploomber.tasks import NotebookRunner
     >>> def touch_root(fn):
-    >>>     Path(str(fn)).touch()
+    ...     Path(str(fn)).touch()
 
     >>> # Use the task-level hook "on_finish" to exit DAG gracefully.
     >>> dag = DAG(executor='parallel') # use with default values
-    >>> t = PythonCallable(touch_root, File('file.txt'), dag)
-    >>> t.on_finish = early_stop
-    >>> dag.build()  # This will return None
+    ... t = NotebookRunner(touch_root, File('file.txt'), dag)
+    ... t.on_finish = early_stop
+    ... dag.build()
 
     See Also
     --------
     ploomber.executors.Parallel :
         Parallel executor
     """
+
     def __init__(self,
                  build_in_subprocess=True,
                  catch_exceptions=True,
@@ -198,6 +201,7 @@ class Serial(Executor):
 
 
 class LazyFunction:
+
     def __init__(self, fn, kwargs, task):
         self.fn = fn
         self.kwargs = kwargs
@@ -209,14 +213,14 @@ class LazyFunction:
 
 def catch_warnings(fn, warnings_all):
     """
-    Catch all warnings on the current task (except DeprecationWarning) 
+    Catch all warnings on the current task (except DeprecationWarning)
     and append them to warnings_all. Runs if the parameter catch_warnings
     is true.
 
     Parameters
     ----------
     fn : function
-        A LazyFunction that automatically calls catch_warnings, with parameters 
+        A LazyFunction that automatically calls catch_warnings, with parameters
         from the main function (warnings_all) and the current scheduled task.
 
     warnings_all: BuildWarningsCollector object
@@ -237,14 +241,14 @@ def catch_warnings(fn, warnings_all):
 
 def catch_exceptions(fn, exceptions_all):
     """
-    If there is an exception, log it and append it to warnings_all. Runs if 
+    If there is an exception, log it and append it to warnings_all. Runs if
     the parameter catch_exceptions is true.
 
     Parameters
     ----------
     fn : function
-        A LazyFunction that automatically calls catch_exceptions, with 
-        parameters from the main function (exceptions_all) and the 
+        A LazyFunction that automatically calls catch_exceptions, with
+        parameters from the main function (exceptions_all) and the
         current scheduled task.
 
     exceptions_all: BuildExceptionsCollector object
@@ -273,13 +277,13 @@ def catch_exceptions(fn, exceptions_all):
 
 def pass_exceptions(fn):
     """
-    Pass all exceptions for the current task and nothing. Runs if 
+    Pass all exceptions for the current task and nothing. Runs if
     both parameters catch_exceptions and catch_warnings are false.
 
     Parameters
     ----------
     fn : function
-        A LazyFunction that automatically calls pass_exceptions on the 
+        A LazyFunction that automatically calls pass_exceptions on the
         current scheduled task.
     """
     # should i still check here for DAGBuildEarlyStop? is it worth
@@ -289,7 +293,7 @@ def pass_exceptions(fn):
 
 def build_in_current_process(task, build_kwargs, reports_all):
     """
-    Execute the current task in the current process. Runs if the parameter 
+    Execute the current task in the current process. Runs if the parameter
     build_in_subprocess is false.
 
     Parameters
@@ -298,7 +302,7 @@ def build_in_current_process(task, build_kwargs, reports_all):
         The current task.
 
     build_kwargs: dict
-        Contains bool catch_exceptions and bool catch_warnings, checks 
+        Contains bool catch_exceptions and bool catch_warnings, checks
         whether to catch exceptions and warnings on the current task.
 
     reports_all: list
@@ -310,7 +314,7 @@ def build_in_current_process(task, build_kwargs, reports_all):
 
 def build_in_subprocess(task, build_kwargs, reports_all):
     """
-    Execute the current task in a subprocess. Runs if the parameter 
+    Execute the current task in a subprocess. Runs if the parameter
     build_in_subprocess is true.
 
     Parameters
@@ -319,7 +323,7 @@ def build_in_subprocess(task, build_kwargs, reports_all):
         The current task.
 
     build_kwargs: dict
-        Contains bool catch_exceptions and bool catch_warnings, checks 
+        Contains bool catch_exceptions and bool catch_warnings, checks
         whether to catch exceptions and warnings on the current task.
 
     reports_all: list

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -429,7 +429,7 @@ class NotebookSource(Source):
         # but only warn
 
         # strict mode: raise and check signature
-        # regular mode: _check_notebook called in NotebookRunner.run
+        # regular mode: _check_notebook called in .run
         if self.static_analysis == 'strict':
             self._check_notebook(raise_=True, check_signature=True)
         else:

--- a/src/ploomber/telemetry.py
+++ b/src/ploomber/telemetry.py
@@ -3,4 +3,6 @@ from ploomber import __version__
 
 POSTHOG_API_KEY = 'phc_P9SpSeypyPwxrMdFn2edOOEooQioF2axppyEeDwtMSP'
 
-telemetry = Telemetry(POSTHOG_API_KEY, package_name='ploomber', version=__version__)
+telemetry = Telemetry(POSTHOG_API_KEY,
+                      package_name='ploomber',
+                      version=__version__)


### PR DESCRIPTION
## Describe your changes
I updated examples in api/executors/serial.py and  api/executors/parallel.py to illustrate that `DAGBuildEarlyStop` allows build to exit gracefully, and added doc strings for private methods in serial.py.

## Issue ticket number and link
Closes #953 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

