### PR TITLE
do not display warning when a task has multiple notebook outputs

### DIFF
--- a/src/ploomber/tasks/notebook.py
+++ b/src/ploomber/tasks/notebook.py
@@ -151,7 +151,9 @@ class NotebookConverter:
     def __init__(self,
                  path_to_output,
                  exporter_name=None,
-                 nbconvert_export_kwargs=None):
+                 nbconvert_export_kwargs=None,
+                 warn_on_ipynb=True):
+        self._warn_on_ipynb = warn_on_ipynb
         self._suffix = Path(path_to_output).suffix
 
         if exporter_name is None:
@@ -185,8 +187,8 @@ class NotebookConverter:
         self._nbconvert_export_kwargs = nbconvert_export_kwargs or {}
 
     def convert(self):
-
-        if self._exporter is None and self._nbconvert_export_kwargs:
+        if (self._warn_on_ipynb and self._exporter is None
+                and self._nbconvert_export_kwargs):
             warnings.warn(
                 f'Output {self._path_to_output!r} is a '
                 'notebook file. nbconvert_export_kwargs '
@@ -738,8 +740,10 @@ class NotebookRunner(NotebookMixin, Task):
                 exporter = nbconvert_exporter_name.get(
                     key) if nbconvert_exporter_name else None
                 self._converter.append(
-                    NotebookConverter(product_nb, exporter,
-                                      nbconvert_export_kwargs))
+                    NotebookConverter(product_nb,
+                                      exporter,
+                                      nbconvert_export_kwargs,
+                                      warn_on_ipynb=False))
 
     @property
     def debug_mode(self):

--- a/tests/tasks/test_notebook.py
+++ b/tests/tasks/test_notebook.py
@@ -488,6 +488,38 @@ Path(product['model']).touch()
     dag.build()
 
 
+# should not have warning when have multiple exports and
+# nbconvert_export_kwargs set
+@pytest.mark.parametrize('product, nb_product_key, nbconvert_exporter_name', [
+    ({
+        'nb': File(Path('out.pdf')),
+        'file': File(Path('another', 'data', 'file.txt')),
+    }, 'nb', 'webpdf')
+])
+def test_multiple_nb_no_kwargs_warning(product, nb_product_key,
+                                       nbconvert_exporter_name):
+    dag = DAG()
+
+    code = """
+# + tags=["parameters"]
+var = None
+
+# +
+from pathlib import Path
+Path(product['file']).touch()
+    """
+
+    NotebookRunner(code,
+                   product=product,
+                   dag=dag,
+                   ext_in='py',
+                   nbconvert_exporter_name=nbconvert_exporter_name,
+                   nb_product_key=nb_product_key,
+                   nbconvert_export_kwargs=dict(exclude_input=True),
+                   name='nb')
+    dag.build()
+
+
 @pytest.mark.parametrize('product, nb_product_key, nbconvert_exporter_name', [
     (
         {


### PR DESCRIPTION
## Describe your changes

Turns out this wasn't actually a problem, but we weren't testing for it so I added a test.
https://github.com/ploomber/ploomber/issues/980#issuecomment-1241199520

## Issue ticket number and link
Closes #980

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

