### PR TITLE
Allow for setting `null` clients

### DIFF
--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -518,6 +518,8 @@ class DAGSpec(MutableMapping):
 
         if clients:
             for class_name, dotted_path_spec in clients.items():
+                if dotted_path_spec is None:
+                    continue
                 dps = dotted_path.DottedPath(dotted_path_spec,
                                              lazy_load=self._lazy_import,
                                              allow_return_none=False)

--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -471,8 +471,9 @@ def _init_product(task_dict, meta, task_class, root_path, lazy_import):
 
     CLASS = _find_product_class(task_class, task_dict, meta)
 
-    if 'product_client' in task_dict:
-        dp = dotted_path.DottedPath(task_dict.pop('product_client'),
+    dotted_path_spec = task_dict.pop('product_client', None)
+    if dotted_path_spec is not None:
+        dp = dotted_path.DottedPath(dotted_path_spec,
                                     lazy_load=lazy_import,
                                     allow_return_none=False)
 
@@ -596,8 +597,9 @@ def _resolve_if_file(product_raw, relative_to, class_):
 
 
 def _init_client(task_dict, lazy_import):
-    if 'client' in task_dict:
-        dp = dotted_path.DottedPath(task_dict.pop('client'),
+    dotted_path_spec = task_dict.pop('client', None)
+    if dotted_path_spec is not None:
+        dp = dotted_path.DottedPath(dotted_path_spec,
                                     lazy_load=lazy_import,
                                     allow_return_none=False)
 

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -1510,6 +1510,35 @@ def get(a=None):
     assert isinstance(dag.clients[SQLScript], Mock)
 
 
+def test_set_null_client(tmp_sample_tasks):
+    Path('test_sets_clients.py').write_text("""
+from unittest.mock import Mock
+
+def get(a=None):
+    return Mock()
+""")
+
+    spec = DAGSpec({
+        'meta': {
+            'extract_product': False,
+            'extract_upstream': True,
+        },
+        'tasks': [
+            {
+                'source': 'sample.sql',
+                'product': ['name', 'table']
+            },
+        ],
+        'clients': {
+            'SQLScript': None
+        }
+    })
+
+    dag = spec.to_dag()
+
+    assert len(dag.clients) == 0
+
+
 def test_validate_product_default_class_keys():
     spec = {
         'meta': {

--- a/tests/spec/test_taskspec.py
+++ b/tests/spec/test_taskspec.py
@@ -102,6 +102,16 @@ def test_task_class_from_source_str_invalid_path():
             },
             NotebookRunner,
         ],
+        # null clients where it is valid
+        [
+            {
+                'source': 'sample.py',
+                'product': 'out.ipynb',
+                'client': None,
+                'product_client': None
+            },
+            NotebookRunner,
+        ],
         [
             {
                 'source': 'sample.sql',


### PR DESCRIPTION
## Describe your changes

The aim here is to be able to dynamically set clients based on the `env.yaml`. In some cases, for example the `File` client one might not want to set a client in the dev environment but might want to backup to the Cloud in production. This allows for that by setting

env.dev.yaml:
```
file_client: ~
```

env.prod.yaml:
```
file_client: clients.get_client
```

pipeline.yaml
```
clients:
  File: "{{ file_client }}"
```

When the client is `~` this basically behaves no differently than if the key was missing in `pipeline.yaml` entirely. 

## Issue ticket number and link
Closes #1015

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

