### PR TITLE
Add improved error message when missing product key

### DIFF
--- a/src/ploomber/exceptions.py
+++ b/src/ploomber/exceptions.py
@@ -195,6 +195,13 @@ class RawBaseException(BaseException):
 
     def get_message(self):
         return str(self)
+class MissingKeysValidationError(ValidationError):
+    """Raised when failed to validate input data because keys were missing
+    """
+
+    def __init__(self, message, missing_keys):
+        self.missing_keys = missing_keys
+        super().__init__(message)
 
 
 class NetworkException(BaseException):

--- a/src/ploomber/exceptions.py
+++ b/src/ploomber/exceptions.py
@@ -195,6 +195,8 @@ class RawBaseException(BaseException):
 
     def get_message(self):
         return str(self)
+
+
 class MissingKeysValidationError(ValidationError):
     """Raised when failed to validate input data because keys were missing
     """

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -84,6 +84,7 @@ predictions using ``OnlineDAG().predict()``. See ``OnlineDAG`` documentation
 for details.
 """
 import fnmatch
+import json
 import os
 import yaml
 import logging
@@ -425,10 +426,13 @@ class DAGSpec(MutableMapping):
                                      reload=reload))
                     except MissingKeysValidationError as e:
                         example_spec = _build_example_spec(t["source"])
-                        fixed_example = yaml.dump(example_spec,
-                                                  sort_keys=False)
+                        if isinstance(data, dict):
+                            example_str = json.dumps(example_spec)
+                        else:
+                            example_str = yaml.dump(example_spec,
+                                                    sort_keys=False)
                         e.message += '\nTo fix it, add the missing key (example):\n\n{}'.format(
-                            fixed_example)
+                            example_str)
                         raise e
                 self.data['tasks'] = task_specs
         else:

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -103,7 +103,8 @@ from ploomber.spec.taskspec import TaskSpec, suffix2taskclass
 from ploomber.util import validate
 from ploomber.util import default
 from ploomber.dag.dagconfiguration import DAGConfiguration
-from ploomber.exceptions import DAGSpecInitializationError, MissingKeysValidationError
+from ploomber.exceptions import (DAGSpecInitializationError,
+                                 MissingKeysValidationError)
 from ploomber.env.envdict import EnvDict
 from ploomber.env.expand import (expand_raw_dictionary_and_extract_tags,
                                  expand_raw_dictionaries_and_extract_tags)
@@ -432,8 +433,8 @@ class DAGSpec(MutableMapping):
                                                     sort_keys=False)
                         else:
                             example_str = json.dumps(example_spec)
-                        e.message += '\nTo fix it, add the missing key (example):\n\n{}'.format(
-                            example_str)
+                        e.message += '\nTo fix it, add the missing key '
+                        '(example):\n\n{}'.format(example_str)
                         raise e
                 self.data['tasks'] = task_specs
         else:

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -433,8 +433,8 @@ class DAGSpec(MutableMapping):
                                                     sort_keys=False)
                         else:
                             example_str = json.dumps(example_spec)
-                        e.message += '\nTo fix it, add the missing key '
-                        '(example):\n\n{}'.format(example_str)
+                        e.message += ('\nTo fix it, add the missing key ' +
+                                      '(example):\n\n{}').format(example_str)
                         raise e
                 self.data['tasks'] = task_specs
         else:

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -102,7 +102,7 @@ from ploomber.spec.taskspec import TaskSpec, suffix2taskclass
 from ploomber.util import validate
 from ploomber.util import default
 from ploomber.dag.dagconfiguration import DAGConfiguration
-from ploomber.exceptions import DAGSpecInitializationError
+from ploomber.exceptions import DAGSpecInitializationError, MissingKeysValidationError
 from ploomber.env.envdict import EnvDict
 from ploomber.env.expand import (expand_raw_dictionary_and_extract_tags,
                                  expand_raw_dictionaries_and_extract_tags)
@@ -414,13 +414,23 @@ class DAGSpec(MutableMapping):
             # make sure the folder where the pipeline is located is in sys.path
             # otherwise dynamic imports needed by TaskSpec will fail
             with add_to_sys_path(self._parent_path, chdir=False):
-                self.data['tasks'] = [
-                    TaskSpec(t,
-                             self.data['meta'],
-                             project_root=project_root,
-                             lazy_import=lazy_import,
-                             reload=reload) for t in self.data['tasks']
-                ]
+                task_specs = []
+                for t in self.data['tasks']:
+                    try:
+                        task_specs.append(
+                            TaskSpec(t,
+                                     self.data['meta'],
+                                     project_root=project_root,
+                                     lazy_import=lazy_import,
+                                     reload=reload))
+                    except MissingKeysValidationError as e:
+                        example_spec = _build_example_spec(t["source"])
+                        fixed_example = yaml.dump(example_spec,
+                                                  sort_keys=False)
+                        e.message += '\nTo fix it, add the missing key (example):\n\n{}'.format(
+                            fixed_example)
+                        raise e
+                self.data['tasks'] = task_specs
         else:
             self.data['meta'] = Meta.empty()
 
@@ -804,8 +814,12 @@ def process_tasks(dag, dag_spec, root_path=None):
     for task_dict in dag_spec['tasks']:
         # init source to extract product
         fn = task_dict['class']._init_source
-        kwargs = {'kwargs': {}, 'extract_up': extract_up,
-                  'extract_prod': extract_prod, **task_dict}
+        kwargs = {
+            'kwargs': {},
+            'extract_up': extract_up,
+            'extract_prod': extract_prod,
+            **task_dict
+        }
         source = call_with_dictionary(fn, kwargs=kwargs)
 
         if extract_prod:
@@ -904,3 +918,23 @@ def _expand_upstream(upstream, task_names):
             expanded[up] = None
 
     return expanded
+
+
+def _build_example_spec(source):
+    """
+    Build an example spec from just the source.
+    """
+    example_spec = {}
+    example_spec["source"] = source
+    if suffix2taskclass[Path(source).suffix] is NotebookRunner:
+        example_product = {
+            "nb": "products/report.ipynb",
+            "data": "products/data.csv",
+        }
+    else:
+        example_product = "products/data.csv"
+    example_spec = [{
+        "source": source,
+        "product": example_product,
+    }]
+    return example_spec

--- a/src/ploomber/spec/dagspec.py
+++ b/src/ploomber/spec/dagspec.py
@@ -229,9 +229,10 @@ class DAGSpec(MutableMapping):
               look_up_project_root_recursively):
         self._lazy_import = lazy_import
         self._name = None
+        data_argument_is_filepath = isinstance(data, (str, Path))
 
         # initialized with a path to a yaml file...
-        if isinstance(data, (str, Path)):
+        if data_argument_is_filepath:
             # TODO: test this
             if parent_path is not None:
                 raise ValueError('parent_path must be None when '
@@ -426,11 +427,11 @@ class DAGSpec(MutableMapping):
                                      reload=reload))
                     except MissingKeysValidationError as e:
                         example_spec = _build_example_spec(t["source"])
-                        if isinstance(data, dict):
-                            example_str = json.dumps(example_spec)
-                        else:
+                        if data_argument_is_filepath:
                             example_str = yaml.dump(example_spec,
                                                     sort_keys=False)
+                        else:
+                            example_str = json.dumps(example_spec)
                         e.message += '\nTo fix it, add the missing key (example):\n\n{}'.format(
                             example_str)
                         raise e

--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -265,16 +265,10 @@ class TaskSpec(MutableMapping):
         else:
             required = {'product', 'source'}
 
-        try:
-            validate.keys(valid=None,
-                          passed=self.data,
-                          required=required,
-                          name=repr(self))
-        except MissingKeysValidationError as e:
-            example_spec = _build_example_spec(self.data["source"])
-            fixed_example = yaml.dump(example_spec, sort_keys=False)
-            e.message += '\nTo fix it, add the missing key (example):\n\n{}'.format(fixed_example)
-            raise e
+        validate.keys(valid=None,
+                      passed=self.data,
+                      required=required,
+                      name=repr(self))
 
         if self.meta['extract_upstream'] and self.data.get('upstream'):
             raise DAGSpecInitializationError(
@@ -668,22 +662,3 @@ def _process_dotted_paths(grid_spec):
             out[key] = value
 
     return out
-
-def _build_example_spec(source):
-    """
-    Build an example spec from just the source.
-    """
-    example_spec = {}
-    example_spec["source"] = source
-    if suffix2taskclass[Path(source).suffix] is tasks.NotebookRunner:
-        example_product = {
-            "nb": "products/report.ipynb",
-            "data": "products/data.csv",
-        }
-    else:
-        example_product = "products/data.csv"
-    example_spec = [{
-        "source": source,
-        "product": example_product,
-    }]
-    return example_spec

--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -19,7 +19,7 @@ from ploomber.util.util import _make_iterable
 from ploomber.util import validate, dotted_path
 from ploomber.tasks.taskgroup import TaskGroup
 from ploomber import validators
-from ploomber.exceptions import DAGSpecInitializationError, MissingKeysValidationError
+from ploomber.exceptions import DAGSpecInitializationError
 from ploomber.products._resources import resolve_resources
 from ploomber.io import pretty_print
 

--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -271,11 +271,9 @@ class TaskSpec(MutableMapping):
                           required=required,
                           name=repr(self))
         except MissingKeysValidationError as e:
-            fixed_example = yaml.dump([{
-                "source": self.data["source"],
-                "product": "products/data.csv"
-            }])
-            e.message += '\nTo fix it:\n\n{}'.format(fixed_example)
+            example_spec = _build_example_spec(self.data["source"])
+            fixed_example = yaml.dump(example_spec, sort_keys=False)
+            e.message += '\nTo fix it, add the missing key (example):\n\n{}'.format(fixed_example)
             raise e
 
         if self.meta['extract_upstream'] and self.data.get('upstream'):
@@ -670,3 +668,22 @@ def _process_dotted_paths(grid_spec):
             out[key] = value
 
     return out
+
+def _build_example_spec(source):
+    """
+    Build an example spec from just the source.
+    """
+    example_spec = {}
+    example_spec["source"] = source
+    if suffix2taskclass[Path(source).suffix] is tasks.NotebookRunner:
+        example_product = {
+            "nb": "products/report.ipynb",
+            "data": "products/data.csv",
+        }
+    else:
+        example_product = "products/data.csv"
+    example_spec = [{
+        "source": source,
+        "product": example_product,
+    }]
+    return example_spec

--- a/src/ploomber/spec/taskspec.py
+++ b/src/ploomber/spec/taskspec.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from collections.abc import MutableMapping, Mapping
 import platform
 from difflib import get_close_matches
-import yaml
 
 from ploomber import tasks, products
 from ploomber.util.util import _make_iterable

--- a/src/ploomber/util/validate.py
+++ b/src/ploomber/util/validate.py
@@ -1,4 +1,4 @@
-from ploomber.exceptions import ValidationError
+from ploomber.exceptions import MissingKeysValidationError, ValidationError
 from ploomber.io import pretty_print
 
 
@@ -19,5 +19,5 @@ def keys(valid, passed, required=None, name='spec'):
         missing = set(required) - passed
 
         if missing:
-            raise ValidationError(f"Error validating {name}. Missing "
-                                  f"keys: { pretty_print.iterable(missing)}")
+            raise MissingKeysValidationError(f"Error validating {name}. Missing "
+                                             f"keys: { pretty_print.iterable(missing)}", missing_keys=missing)

--- a/src/ploomber/util/validate.py
+++ b/src/ploomber/util/validate.py
@@ -19,5 +19,7 @@ def keys(valid, passed, required=None, name='spec'):
         missing = set(required) - passed
 
         if missing:
-            raise MissingKeysValidationError(f"Error validating {name}. Missing "
-                                             f"keys: { pretty_print.iterable(missing)}", missing_keys=missing)
+            raise MissingKeysValidationError(
+                f"Error validating {name}. Missing "
+                f"keys: { pretty_print.iterable(missing)}",
+                missing_keys=missing)

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -202,14 +202,15 @@ def test_validation_help_message_yaml_nb(tmp_directory):
 
 def test_validation_help_message_dict():
     with pytest.raises(ValidationError) as excinfo:
-        DAGSpec({"tasks": [{"source": "mytask.sh",}]})
+        DAGSpec({"tasks": [{"source": "mytask.sh"}]})
     assert '"product": "products/data.csv"' in excinfo.value.message
 
 
 def test_validation_help_message_dict_nb():
     with pytest.raises(ValidationError) as excinfo:
-        DAGSpec({"tasks": [{"source": "mytask.py",}]})
-    assert '"product": {"nb": "products/report.ipynb", "data": "products/data.csv"}' in excinfo.value.message
+        DAGSpec({"tasks": [{"source": "mytask.py"}]})
+    assert ('"product": {"nb": "products/report.ipynb", ' +
+            'data": "products/data.csv"}') in excinfo.value.message
 
 
 def test_python_callables_spec(tmp_directory, add_current_to_sys_path):

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -176,6 +176,42 @@ def test_validate_meta_keys():
         DAGSpec({'tasks': [], 'meta': {'invalid_key': None}})
 
 
+def test_validation_help_message_yaml(tmp_directory):
+    Path("pipeline.yaml").write_text("""tasks:
+  - source: mytask.sh
+""")
+    Path("mytask.sh").write_text("""echo Hello, world!""")
+    with pytest.raises(ValidationError) as excinfo:
+        DAGSpec("pipeline.yaml")
+    assert """- source: mytask.sh
+  product: products/data.csv""" in excinfo.value.message
+
+
+def test_validation_help_message_yaml_nb(tmp_directory):
+    Path("pipeline.yaml").write_text("""tasks:
+  - source: mytask.py
+""")
+    Path("mytask.py").write_text("""print("Hello, world!")""")
+    with pytest.raises(ValidationError) as excinfo:
+        DAGSpec("pipeline.yaml")
+    assert """- source: mytask.py
+  product:
+    nb: products/report.ipynb
+    data: products/data.csv""" in excinfo.value.message
+
+
+def test_validation_help_message_dict():
+    with pytest.raises(ValidationError) as excinfo:
+        DAGSpec({"tasks": [{"source": "mytask.sh",}]})
+    assert '"product": "products/data.csv"' in excinfo.value.message
+
+
+def test_validation_help_message_dict_nb():
+    with pytest.raises(ValidationError) as excinfo:
+        DAGSpec({"tasks": [{"source": "mytask.py",}]})
+    assert '"product": {"nb": "products/report.ipynb", "data": "products/data.csv"}' in excinfo.value.message
+
+
 def test_python_callables_spec(tmp_directory, add_current_to_sys_path):
     Path('test_python_callables_spec.py').write_text("""
 def task1(product):

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -209,8 +209,8 @@ def test_validation_help_message_dict():
 def test_validation_help_message_dict_nb():
     with pytest.raises(ValidationError) as excinfo:
         DAGSpec({"tasks": [{"source": "mytask.py"}]})
-    assert ('"product": {"nb": "products/report.ipynb", ' +
-            'data": "products/data.csv"}') in excinfo.value.message
+    assert ('"product": {"nb": "products/report.ipynb", ' + \
+            '"data": "products/data.csv"}') in excinfo.value.message
 
 
 def test_python_callables_spec(tmp_directory, add_current_to_sys_path):

--- a/tests/spec/test_dagspec.py
+++ b/tests/spec/test_dagspec.py
@@ -209,7 +209,7 @@ def test_validation_help_message_dict():
 def test_validation_help_message_dict_nb():
     with pytest.raises(ValidationError) as excinfo:
         DAGSpec({"tasks": [{"source": "mytask.py"}]})
-    assert ('"product": {"nb": "products/report.ipynb", ' + \
+    assert ('"product": {"nb": "products/report.ipynb", ' +
             '"data": "products/data.csv"}') in excinfo.value.message
 
 


### PR DESCRIPTION
## Describe your changes
I added an example to fix the error message for ValidationError when it fails on account of a missing `product` key.
I implemented it as an exception handler and special named exception in `dagspec.py`.

## Issue ticket number and link
Closes #628 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

## Example output:

I made these test projects to reproduce the behavior I added: [testdata.zip](https://github.com/ploomber/ploomber/files/9699304/testdata.zip)

In case the product will be a data file:

```bash
~/code/ploomber-hack/testdata/no_nb
venv ❯ ploomber build                    
Loading pipeline...
Error: Error validating TaskSpec({'source': 'mytask.sh', 'upstream': None}). Missing keys: 'product'
To fix it, add the missing key (example):

- source: mytask.sh
  product: products/data.csv

~/code/ploomber-hack/testdata/no_nb
venv ❯ python ../load_dagspec_no_notebook.py                                      
Traceback (most recent call last):
  File "../load_dagspec_no_notebook.py", line 3, in <module>
    spec = DAGSpec(data={"tasks": [{"source": "mytask.sh",}]}) # load spec
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/dagspec.py", line 221, in __init__
    self._init(data=data,
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/dagspec.py", line 437, in _init
    raise e
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/dagspec.py", line 423, in _init
    TaskSpec(t,
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/taskspec.py", line 225, in __init__
    self.validate()
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/taskspec.py", line 268, in validate
    validate.keys(valid=None,
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/util/validate.py", line 22, in keys
    raise MissingKeysValidationError(f"Error validating {name}. Missing "
ploomber.exceptions.MissingKeysValidationError: Error validating TaskSpec({'source': 'mytask.sh', 'upstream': None}). Missing keys: 'product'
To fix it, add the missing key (example):

[{"source": "mytask.sh", "product": "products/data.csv"}]
```

In case the product will be a notebook, add the `nb` key:

```bash
~/code/ploomber-hack/testdata/notebook
venv ❯ ploomber build
Loading pipeline...
Error: Error validating TaskSpec({'source': 'mytask.py', 'upstream': None}). Missing keys: 'product'
To fix it, add the missing key (example):

- source: mytask.py
  product:
    nb: products/report.ipynb
    data: products/data.csv

~/code/ploomber-hack/testdata/notebook
venv ❯ python ../load_dagspec_notebook.py
Traceback (most recent call last):
  File "../load_dagspec_notebook.py", line 3, in <module>
    spec = DAGSpec(data={"tasks": [{"source": "mytask.py",}]}) # load spec
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/dagspec.py", line 221, in __init__
    self._init(data=data,
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/dagspec.py", line 437, in _init
    raise e
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/dagspec.py", line 423, in _init
    TaskSpec(t,
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/taskspec.py", line 225, in __init__
    self.validate()
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/spec/taskspec.py", line 268, in validate
    validate.keys(valid=None,
  File "/home/benjis/code/ploomber-hack/ploomber-bugfix/src/ploomber/util/validate.py", line 22, in keys
    raise MissingKeysValidationError(f"Error validating {name}. Missing "
ploomber.exceptions.MissingKeysValidationError: Error validating TaskSpec({'source': 'mytask.py', 'upstream': None}). Missing keys: 'product'
To fix it, add the missing key (example):

[{"source": "mytask.py", "product": {"nb": "products/report.ipynb", "data": "products/data.csv"}}]
```


