### PR TITLE
Merge nested `env` keys when using `import_from`

### DIFF
--- a/src/ploomber/env/envdict.py
+++ b/src/ploomber/env/envdict.py
@@ -131,7 +131,7 @@ class EnvDict(Mapping):
             import_from = _get_import_from(raw_data, path_to_here)
 
             if import_from:
-                raw_data = {**import_from, **raw_data}
+                raw_data = deep_merge(import_from, raw_data)
 
             # check raw data is ok
             validate.raw_data_keys(raw_data)
@@ -472,3 +472,14 @@ def find_tags_in_dict(d):
         tags = tags | util.get_tags_in_str(k)
 
     return tags
+
+
+def deep_merge(a: dict, b: dict) -> dict:
+    result = deepcopy(a)
+    for bk, bv in b.items():
+        av = result.get(bk)
+        if isinstance(av, dict) and isinstance(bv, dict):
+            result[bk] = deep_merge(av, bv)
+        else:
+            result[bk] = deepcopy(bv)
+    return result

--- a/tests/env/test_env.py
+++ b/tests/env/test_env.py
@@ -936,6 +936,9 @@ def test_import_from_another_file(tmp_directory):
     Path('base.yaml').write_text("""
 key: value
 base: 42
+nested:
+  key_1: value_1
+  key_2: value_2
 """)
 
     env = EnvDict(
@@ -943,13 +946,18 @@ base: 42
             'meta': {
                 'import_from': 'base.yaml'
             },
-            'key': 'new_value'
+            'key': 'new_value',
+            'nested': {
+                'key_1': 'new_value_1',
+            },
         },
         path_to_here=os.getcwd(),
     )
 
     assert env['key'] == 'new_value'
     assert env['base'] == 42
+    assert env['nested']['key_1'] == 'new_value_1'
+    assert env['nested']['key_2'] == 'value_2'
     # this section is for config, and should not be visible
     assert 'meta' not in env
 


### PR DESCRIPTION
## Describe your changes

Previously, if you had nested keys in your `env.yaml` it wasn't possible to override a subset of them.

For example:

`env.yaml`
```yaml
nested:
  key_1: value_1
  key_2: value_2
```
and
`env.prod.yaml`
```yaml
meta:
  import_from: env.yaml

nested:
  key_1: new_value_1
```

would result in:

```yaml
nested:
  key_1: new_value_1
```

With these changes the result is:
```yaml
nested:
  key_1: new_value_1
  key_2: value_2
```

This should work to an arbitrary depth.

## Issue ticket number and link
Closes #x 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.
  - I don't think this really needs any additional docs as this is the expected behaviour I'd have thought? 
