### PR TITLE
Pr 1021

### DIFF
--- a/src/ploomber/tasks/notebook.py
+++ b/src/ploomber/tasks/notebook.py
@@ -151,7 +151,9 @@ class NotebookConverter:
     def __init__(self,
                  path_to_output,
                  exporter_name=None,
-                 nbconvert_export_kwargs=None):
+                 nbconvert_export_kwargs=None,
+                 warn_on_ipynb=True):
+        self._warn_on_ipynb = warn_on_ipynb
         self._suffix = Path(path_to_output).suffix
 
         if exporter_name is None:
@@ -186,7 +188,7 @@ class NotebookConverter:
 
     def convert(self):
 
-        if self._exporter is None and self._nbconvert_export_kwargs:
+        if (self._warn_on_ipynb and self._exporter is None and self._nbconvert_export_kwargs):
             warnings.warn(
                 f'Output {self._path_to_output!r} is a '
                 'notebook file. nbconvert_export_kwargs '
@@ -739,7 +741,8 @@ class NotebookRunner(NotebookMixin, Task):
                     key) if nbconvert_exporter_name else None
                 self._converter.append(
                     NotebookConverter(product_nb, exporter,
-                                      nbconvert_export_kwargs))
+                                      nbconvert_export_kwargs,
+                                      warn_on_ipynb=False))
 
     @property
     def debug_mode(self):

--- a/tests/tasks/test_notebook.py
+++ b/tests/tasks/test_notebook.py
@@ -494,17 +494,17 @@ def test_do_not_warn_on_nbconvert_export_kwargs_if_multiple_outputs(
      dag = DAG()
 
      code = """
- # + tags=["parameters"]
- upstream = None
+# + tags=["parameters"]
+upstream = None
 
- # +
- 1 + 1
-     """
+# +
+1 + 1
+    """
 
      NotebookRunner(code,
                     product={
                         'nb': File('out.ipynb'),
-                        'report': File('out.html'),
+                        'report': File('out.html')
                     },
                     dag=dag,
                     ext_in='py',
@@ -513,7 +513,7 @@ def test_do_not_warn_on_nbconvert_export_kwargs_if_multiple_outputs(
                     name='nb')
 
      with warnings.catch_warnings():
-         # fail the test if this displays a warnings
+         # fail the test if this displays warnings
          warnings.simplefilter("error")
          dag.build()
 

--- a/tests/tasks/test_notebook.py
+++ b/tests/tasks/test_notebook.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path, PurePosixPath
 from unittest.mock import ANY, Mock
+import warnings
 
 import jupytext
 import nbconvert
@@ -488,6 +489,35 @@ Path(product['model']).touch()
     dag.build()
 
 
+def test_do_not_warn_on_nbconvert_export_kwargs_if_multiple_outputs(
+         tmp_directory):
+     dag = DAG()
+
+     code = """
+ # + tags=["parameters"]
+ upstream = None
+
+ # +
+ 1 + 1
+     """
+
+     NotebookRunner(code,
+                    product={
+                        'nb': File('out.ipynb'),
+                        'report': File('out.html'),
+                    },
+                    dag=dag,
+                    ext_in='py',
+                    nb_product_key=['nb', 'report'],
+                    nbconvert_export_kwargs=dict(exclude_input=True),
+                    name='nb')
+
+     with warnings.catch_warnings():
+         # fail the test if this displays a warnings
+         warnings.simplefilter("error")
+         dag.build()
+
+
 @pytest.mark.parametrize('product, nb_product_key, nbconvert_exporter_name', [
     (
         {
@@ -523,7 +553,8 @@ Path(product['model']).touch()
         'file': File(Path('another', 'data', 'file.txt')),
     }, 'nb', 'webpdf')
 ])
-def test_multiple_nb_product_success(product, nb_product_key,
+def test_multiple_nb_product_success(tmp_directory,
+                                     product, nb_product_key,
                                      nbconvert_exporter_name):
     dag = DAG()
 


### PR DESCRIPTION
## Describe your changes
This PR is based on PR 1021. Sometimes test_do_not_warn_on_nbconvert_export_kwargs_if_multiple_outputs wouldn't pass, and it is because notebooksource.py/_validate_parameters_cell sometimes fail to find tag "parameters" in the NotebookSource instance initialized from string. 

## Issue ticket number and link
Closes #980 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

