### PR TITLE
Fix #1048 - nb inject fails when using ploomber scaffolding for a package

### DIFF
--- a/src/ploomber/sources/pythoncallablesource.py
+++ b/src/ploomber/sources/pythoncallablesource.py
@@ -128,7 +128,7 @@ class PythonCallableSource(Source):
         self._hot_reload = hot_reload
         self._needs_product = needs_product
         if isinstance(primitive, str):
-            # If the primitive is the string path, the path will be the file invokes the loc, will be lazily set when _loc is loaded 
+            # If the primitive is the string path, the path will be the file invokes the loc, will be lazily set when _loc is loaded
             self._path = None
         elif callable(primitive):
             self._path = self._callable_loader.get_path()

--- a/src/ploomber/sources/pythoncallablesource.py
+++ b/src/ploomber/sources/pythoncallablesource.py
@@ -82,6 +82,7 @@ class CallableLoader:
 
     def get_path(self):
         return getfile(self.load())
+
     @property
     def from_dotted_path(self):
         return self._from_dotted_path
@@ -131,6 +132,7 @@ class PythonCallableSource(Source):
             self._path = None
         elif callable(primitive):
             self._path = self._callable_loader.get_path()
+
     @property
     def hot_reload(self):
         return self._hot_reload

--- a/src/ploomber/sources/pythoncallablesource.py
+++ b/src/ploomber/sources/pythoncallablesource.py
@@ -128,7 +128,8 @@ class PythonCallableSource(Source):
         self._hot_reload = hot_reload
         self._needs_product = needs_product
         if isinstance(primitive, str):
-            # If the primitive is the string path, the path will be the file invokes the loc, will be lazily set when _loc is loaded
+            # If the primitive is the string path
+            # will be lazily set when _loc is loaded
             self._path = None
         elif callable(primitive):
             self._path = self._callable_loader.get_path()

--- a/src/ploomber/sources/pythoncallablesource.py
+++ b/src/ploomber/sources/pythoncallablesource.py
@@ -101,7 +101,7 @@ class PythonCallableSource(Source):
 
     Parameters
     ----------
-    primitive : primitive PythonCallableSource or str
+    primitive : callable or str
         The function to use, an be a callable object or a dotted path string
 
     hot_reload : bool
@@ -128,7 +128,7 @@ class PythonCallableSource(Source):
         self._hot_reload = hot_reload
         self._needs_product = needs_product
         if isinstance(primitive, str):
-            # If the primitive is the string path, the path will be set later
+            # If the primitive is the string path, the path will be the file invokes the loc, will be lazily set when _loc is loaded 
             self._path = None
         elif callable(primitive):
             self._path = self._callable_loader.get_path()
@@ -159,7 +159,7 @@ class PythonCallableSource(Source):
     def loc(self):
         if self._loc is None or self._hot_reload:
             self._loc = self._callable_loader.get_loc()
-            # Lazily set path when _loc is loaded
+            # Set _path by the file invokes the loc
             self._path = Path(self._loc).absolute()
 
         return self._loc

--- a/tests/sources/test_sources.py
+++ b/tests/sources/test_sources.py
@@ -349,6 +349,7 @@ def some_fn():
     assert str(Path(source.loc).resolve()) == f'{loc}:4'
     assert str(Path(source._path).name) == "some_dotted_path.py:4"
 
+
 def test_python_callable_with_nested_dotted_path_does_not_import(
         tmp_directory, add_current_to_sys_path, no_sys_modules_cache):
     Path('nested').mkdir()
@@ -497,6 +498,7 @@ def test_dotted_path_and_callable_give_same_source():
 
 
 def test_error_if_python_callable_does_not_need_product_but_has_it():
+
     def fn(product):
         pass
 

--- a/tests/sources/test_sources.py
+++ b/tests/sources/test_sources.py
@@ -368,7 +368,7 @@ def some_fn():
     assert str(source) == 'def some_fn():\n    pass\n'
     assert source.name == 'some_fn'
     assert str(Path(source.loc).resolve()) == f'{loc}:2'
-    assert str(Path(source._path).name) == "some_dotted_path.py:1"
+    assert str(Path(source._path).name) == "some_dotted_path.py:2"
 
 
 @pytest.mark.parametrize('target_file, dotted_path_str', [

--- a/tests/sources/test_sources.py
+++ b/tests/sources/test_sources.py
@@ -333,7 +333,8 @@ def test_python_callable_properties(path_to_test_pkg):
 
 def test_python_callable_with_dotted_path_does_not_import(
         tmp_directory, add_current_to_sys_path, no_sys_modules_cache):
-    loc = Path('some_dotted_path.py')
+    LOC_PATH_NAME = 'some_dotted_path.py'
+    loc = Path(LOC_PATH_NAME)
     loc.write_text("""
 import some_unknown_package
 
@@ -347,17 +348,18 @@ def some_fn():
     assert str(source) == 'def some_fn():\n    pass\n'
     assert source.name == 'some_fn'
     assert str(Path(source.loc).resolve()) == f'{loc}:4'
-    assert str(Path(source._path).name) == "some_dotted_path.py:4"
+    assert str(Path(source._path).name) == f'{LOC_PATH_NAME}:4'
 
 
 def test_python_callable_with_nested_dotted_path_does_not_import(
         tmp_directory, add_current_to_sys_path, no_sys_modules_cache):
+    LOC_PATH_NAME = 'some_dotted_path.py'
     Path('nested').mkdir()
     Path('nested', '__init__.py').write_text("""
 import some_unknown_package
 """)
 
-    loc = Path('nested', 'some_dotted_path.py').resolve()
+    loc = Path('nested', LOC_PATH_NAME).resolve()
     loc.write_text("""
 def some_fn():
     pass
@@ -369,7 +371,7 @@ def some_fn():
     assert str(source) == 'def some_fn():\n    pass\n'
     assert source.name == 'some_fn'
     assert str(Path(source.loc).resolve()) == f'{loc}:2'
-    assert str(Path(source._path).name) == "some_dotted_path.py:2"
+    assert str(Path(source._path).name) == f'{LOC_PATH_NAME}:2'
 
 
 @pytest.mark.parametrize('target_file, dotted_path_str', [

--- a/tests/sources/test_sources.py
+++ b/tests/sources/test_sources.py
@@ -347,7 +347,7 @@ def some_fn():
     assert str(source) == 'def some_fn():\n    pass\n'
     assert source.name == 'some_fn'
     assert str(Path(source.loc).resolve()) == f'{loc}:4'
-
+    assert str(Path(source._path).name) == "some_dotted_path.py:4"
 
 def test_python_callable_with_nested_dotted_path_does_not_import(
         tmp_directory, add_current_to_sys_path, no_sys_modules_cache):
@@ -368,6 +368,7 @@ def some_fn():
     assert str(source) == 'def some_fn():\n    pass\n'
     assert source.name == 'some_fn'
     assert str(Path(source.loc).resolve()) == f'{loc}:2'
+    assert str(Path(source._path).name) == "some_dotted_path.py:1"
 
 
 @pytest.mark.parametrize('target_file, dotted_path_str', [

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -169,6 +169,7 @@ def test_python_callable_with_file():
     assert str(t.product) == 'file.txt'
     assert str(t.source) == ('def touch(product):\n    '
                              'Path(str(product)).touch()\n')
+    assert str(Path(t.source._path).name) == "test_tasks.py"
 
 
 def test_postgresscript_with_relation(pg_client_and_schema):


### PR DESCRIPTION
## Describe your changes

This PR is to fix Fix #1048. 
The user was not able to execute `nb --inject` after initializing the empty package project with `scaffold --package`

### Problem Root Cause

https://github.com/ploomber/ploomber/blob/master/src/ploomber/cli/nb.py#L84

The function was trying to access the class `PythonCallable` with `_path` attribute. However, the `_path` member only defined in `NotebookSource`

### Fix

By setting the _path attribute in `PythonCallable` class according to the primitive type

### Test Case

Add some test cases:
- [x] PythonCallableSource with callable type in `tests/tasks/test_tasks.py`
- [x] PythonCallableSource with string path type in `tests/sources/test_sources.py`

### Description

Discussion Items (may convert to action items later):
- [ ] The definition of the path of the callable primitive type should be the file invokes the PythonCallable? e.g. Calling the `PythonCallable` API in the `test_tasks.py`, the path name should also be `test_tasks.py`?
- [ ] Should we consider making `_path` in PythonCallableSource a public member, since it was accessed & used in application level
- [x] Think about side-effects - test if [_get_default_task_to_inject_by_template_name](https://github.com/ploomber/ploomber/blob/master/src/ploomber/cli/nb.py#L67) can be executed successfully
- [x] Investigate the codebase, what scenarios are for `PythonCallableSource` and  `NotebookSource`
- [x] Need to check the codebase if Source classes are not having `_path` member
- [ ] How about stdin mode in Python CLI?

Todo Items:
- [x] Identify the problem 
- [x] Reproduce the issue in the unit testing level
- [x] Cleanup the code

## Issue ticket number and link
[Closes #1048
](https://github.com/ploomber/ploomber/issues/1048)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [ ] I have added the right documentation (when needed). Product update? If yes, write one line about this update.
