### PR TITLE
Fix: Noqa coming up on docs

### DIFF
--- a/src/ploomber/clients/storage/gcloud.py
+++ b/src/ploomber/clients/storage/gcloud.py
@@ -155,11 +155,11 @@ class GCloudStorageClient(AbstractStorageClient):
 
     Notes
     -----
-    `Complete example using the Spec API <https://github.com/ploomber/projects/tree/master/templates/google-cloud>`_ # noqa
+    `Complete example using the Spec API <https://github.com/ploomber/projects/tree/master/templates/google-cloud>`_ 
 
     If a notebook (or script) task fails, the partially executed ``.ipynb``
     file will be uploaded using this client.
-    """
+    """ # noqa
     @requires(['google.cloud.storage'],
               name='GCloudStorageClient',
               pip_names=['google-cloud-storage'])

--- a/src/ploomber/tasks/notebook.py
+++ b/src/ploomber/tasks/notebook.py
@@ -524,8 +524,8 @@ class NotebookRunner(NotebookMixin, Task):
             Support for generating output notebooks in multiple formats, see
             example above.
 
-    `nbconvert's documentation <https://nbconvert.readthedocs.io/en/latest/config_options.html#preprocessor-options>`_ # noqa
-    """
+    `nbconvert's documentation <https://nbconvert.readthedocs.io/en/latest/config_options.html#preprocessor-options>`_ 
+    """ # noqa
 
     PRODUCT_CLASSES_ALLOWED = (File,)
 

--- a/src/ploomber/tasks/sql.py
+++ b/src/ploomber/tasks/sql.py
@@ -193,7 +193,7 @@ class SQLDump(io.FileLoaderMixin, ClientMixin, Task):
           - source: script.sql
             product: data.parquet
 
-    `Full spec API example. <https://github.com/ploomber/projects/tree/master/cookbook/sql-dump>`_ # noqa
+    `Full spec API example. <https://github.com/ploomber/projects/tree/master/cookbook/sql-dump>`_ 
 
     Python API:
 
@@ -231,7 +231,7 @@ class SQLDump(io.FileLoaderMixin, ClientMixin, Task):
     --------
     ploomber.clients.SQLScript :
         A task to execute a SQL script and create a table/view as product
-    """
+    """ # noqa
     PRODUCT_CLASSES_ALLOWED = (File, GenericProduct)
 
     def __init__(self,

--- a/src/ploomber/tasks/tasks.py
+++ b/src/ploomber/tasks/tasks.py
@@ -177,7 +177,7 @@ class PythonCallable(Task):
             ``debug`` constructor flag renamed to ``debug_mode`` to avoid
             conflicts with the ``debug`` method.
 
-    More `examples using the Python API. <https://github.com/ploomber/projects/tree/master/python-api-examples>`_ # noqa
+    More `examples using the Python API. <https://github.com/ploomber/projects/tree/master/python-api-examples>`_ 
 
     The ``executor=Serial(build_in_subprocess=False)`` argument is only
     required if copy-pasting the example in a Python session. If you store the
@@ -195,7 +195,7 @@ class PythonCallable(Task):
         :class: text-editor
 
         python script.py
-    """
+    """ # noqa
 
     def __init__(
         self,


### PR DESCRIPTION
## Describe your changes

Fix Noqa issue on multiple docs

### ploomber.clients.GCloudStorageClient
Before:
<img width="756" alt="Screenshot 2023-01-30 at 5 41 21 PM" src="https://user-images.githubusercontent.com/123580782/215612799-41a6caf0-5c78-44b2-a812-9cff24f37557.png">

After:
<img width="814" alt="Screenshot 2023-01-30 at 5 41 18 PM" src="https://user-images.githubusercontent.com/123580782/215612807-f0bbe0d5-2015-435c-8cd9-a28846a3cba9.png">

### ploomber.tasks.SQLDump
Before:
<img width="454" alt="Screenshot 2023-01-30 at 5 42 43 PM" src="https://user-images.githubusercontent.com/123580782/215613005-e4726a77-54cf-4c3a-99e2-9fe11f6c34a6.png">

After:
<img width="347" alt="Screenshot 2023-01-30 at 5 42 40 PM" src="https://user-images.githubusercontent.com/123580782/215613010-0055f727-2b94-424b-9962-a0b419bb8981.png">

### ploomber.tasks.NotebookRunner
Before:
<img width="346" alt="Screenshot 2023-01-30 at 5 44 49 PM" src="https://user-images.githubusercontent.com/123580782/215613292-428fd248-d099-43ac-a829-2dc7a49b60c1.png">

After:
<img width="327" alt="Screenshot 2023-01-30 at 5 44 52 PM" src="https://user-images.githubusercontent.com/123580782/215613287-be4ba78a-a031-4502-b88c-c5d91c075dae.png">

### ploomber.tasks.PythonCallable
Before:
<img width="1039" alt="Screenshot 2023-01-30 at 5 45 44 PM" src="https://user-images.githubusercontent.com/123580782/215613466-482f82a4-8b39-4cdb-a632-976e720376de.png">

After:
<img width="1018" alt="Screenshot 2023-01-30 at 5 46 01 PM" src="https://user-images.githubusercontent.com/123580782/215613472-4589a135-59b1-45dc-9d18-bfd49204b105.png">


## Issue ticket number and link
Closes #x 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests (when necessary).
- [x] I have added the right documentation (when needed). Product update? If yes, write one line about this update.

