### PR TITLE
fix test_code_highlight adding what was missing to the end of the line

### DIFF
--- a/tests/io_mod/test_terminalwriter.py
+++ b/tests/io_mod/test_terminalwriter.py
@@ -38,6 +38,7 @@ def color_mapping():
             "number": "\x1b[94m",
             "str": "\x1b[33m",
             "print": "\x1b[96m",
+            "end-line": "\x1b[90m\x1b[39;49;00m",
         }
         RE_COLORS = {k: re.escape(v) for k, v in COLORS.items()}
 
@@ -301,9 +302,8 @@ class TestTerminalWriterLineWidth:
         pytest.param(
             True,
             True,
-            "{kw}assert{hl-reset} {number}0{hl-reset}\n",
+            "{kw}assert{hl-reset} {number}0{hl-reset}{end-line}\n",
             id="with markup and code_highlight",
-            marks=pytest.mark.xfail(reason="error with pygments 2.14"),
         ),
         pytest.param(
             True,


### PR DESCRIPTION
## Describe your changes

Investigating why the new version adds `"\x1b[90m\x1b[39;49;00m"` with the pygments 2.14 I came to [this](https://github.com/pytest-dev/pytest/issues/10630) similar pytests issue with the same problem. The solution is to add this to the test.

## Issue number

Closes #1062

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview ploomber start -->
----
:books: Documentation preview :books:: https://ploomber--1138.org.readthedocs.build/en/1138/

<!-- readthedocs-preview ploomber end -->