### PR TITLE
fix link to gh-actions badges on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
   <img src="_static/logo.png" height="250">
 </p>
 
-[![CI Linux](https://github.com/ploomber/ploomber/workflows/CI%20Linux/badge.svg)](https://github.com/ploomber/ploomber/workflows/CI%20Linux/badge.svg)
-[![CI macOS](https://github.com/ploomber/ploomber/workflows/CI%20macOS/badge.svg)](https://github.com/ploomber/ploomber/workflows/CI%20macOS/badge.svg)
-[![CI Windows](https://github.com/ploomber/ploomber/workflows/CI%20Windows/badge.svg)](https://github.com/ploomber/ploomber/workflows/CI%20Windows/badge.svg)
+[![CI Linux](https://github.com/ploomber/ploomber/actions/workflows/ci-unit-linux.yml/badge.svg)](https://github.com/ploomber/ploomber/actions/workflows/ci-unit-linux.yml/badge.svg)
+[![CI macOS](https://github.com/ploomber/ploomber/actions/workflows/ci-unit-macos.yml/badge.svg)](https://github.com/ploomber/ploomber/actions/workflows/ci-unit-macos.yml/badge.svg)
+[![CI Windows](https://github.com/ploomber/ploomber/actions/workflows/ci-unit-windows.yml/badge.svg)](https://github.com/ploomber/ploomber/actions/workflows/ci-unit-windows.yml/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/ploomber/badge/?version=latest)](https://docs.ploomber.io/en/latest/?badge=latest)
 [![PyPI](https://badge.fury.io/py/ploomber.svg)](https://badge.fury.io/py/ploomber)
 [![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/ploomber)](https://anaconda.org/conda-forge/ploomber)


### PR DESCRIPTION
## Describe your changes

I saw that the img of the badges for the [gh-actions](https://github.com/ploomber/ploomber/actions/runs/6836377132/job/18646532359?pr=1138) (on the job broken-links) in the readme give 404 and I made this PR to solve it.

![broken ci badges on readme](https://github.com/ploomber/ploomber/assets/7551922/bd5e13b9-fe2b-4a7d-920b-9c6bc8609fd6)


I don't understand how it was working before, but I changed them as the [gh doc](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge) says so that they point to the last execution of the main branch ("master" in this case).
Check that `pkgmt check-links --only-404` no longer finds any 404 error. Now it looks like this:

![fix ci badges on readme](https://github.com/ploomber/ploomber/assets/7551922/97493465-c9f8-4665-97a3-7dfa6f7391e4)

## Issue number

I don't think there is one created

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview ploomber start -->
----
:books: Documentation preview :books:: https://ploomber--1140.org.readthedocs.build/en/1140/

<!-- readthedocs-preview ploomber end -->