### PR TITLE
modified telemetry tests so that they do not include start event

### DIFF
--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -307,7 +307,6 @@ def test_parses_dag(mock_posthog_capture, tmp_nbs):
 
     my_function()
 
-    print(mock_posthog_capture.call_args_list)
     call2_kwargs = mock_posthog_capture.call_args_list[0][1]
     assert call2_kwargs["properties"]["metadata"]["dag"] == expected_dag_dict
 

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -96,7 +96,7 @@ def test_install_lock_uses_telemetry(
     with pytest.raises(SystemExit):
         install.main(use_lock=True if use_lock else False)
 
-    assert mock.call_count == 2
+    assert mock.call_count == 1
 
 
 def test_install_uses_telemetry(monkeypatch, tmp_directory):
@@ -107,19 +107,13 @@ def test_install_uses_telemetry(monkeypatch, tmp_directory):
     monkeypatch.setattr(install.telemetry, "log_api", mock)
 
     install.main(use_lock=False)
-    assert mock.call_count == 2
+    assert mock.call_count == 1
 
 
 @pytest.mark.parametrize(
     "expected",
     [
         [
-            call(
-                action="ploomber-build-started",
-                metadata={
-                    "argv": ["python", "--entry-point", "test_pkg.entry.with_doc"]
-                },
-            ),
             call(
                 action="ploomber-build-success",
                 total_runtime="0:00:00",
@@ -169,7 +163,7 @@ def test_task_command(args, tmp_nbs, monkeypatch):
     monkeypatch.setattr(task.telemetry, "log_api", mock)
     task.main(catch_exception=False)
 
-    assert mock.call_count == 2
+    assert mock.call_count == 1
 
 
 def test_report_command(monkeypatch, tmp_directory):
@@ -196,7 +190,7 @@ def test_status_command(monkeypatch):
     monkeypatch.setattr(status.telemetry, "log_api", mock)
     status.main(catch_exception=False)
 
-    assert mock.call_count == 2
+    assert mock.call_count == 1
 
 
 def test_interact_uses_telemetry(monkeypatch, tmp_nbs):
@@ -206,7 +200,7 @@ def test_interact_uses_telemetry(monkeypatch, tmp_nbs):
     monkeypatch.setattr(interact.telemetry, "log_api", mock_start_ipython)
     interact.main(catch_exception=False)
 
-    assert mock_start_ipython.call_count == 2
+    assert mock_start_ipython.call_count == 1
 
 
 def test_parse_dag_products(monkeypatch):
@@ -313,7 +307,8 @@ def test_parses_dag(mock_posthog_capture, tmp_nbs):
 
     my_function()
 
-    call2_kwargs = mock_posthog_capture.call_args_list[1][1]
+    print(mock_posthog_capture.call_args_list)
+    call2_kwargs = mock_posthog_capture.call_args_list[0][1]
     assert call2_kwargs["properties"]["metadata"]["dag"] == expected_dag_dict
 
 
@@ -327,5 +322,5 @@ def test_parses_dag_on_exception(mock_posthog_capture, tmp_nbs):
     with pytest.raises(BaseException):
         my_function()
 
-    call2_kwargs = mock_posthog_capture.call_args_list[1][1]
+    call2_kwargs = mock_posthog_capture.call_args_list[0][1]
     assert call2_kwargs["properties"]["metadata"]["dag"] == expected_dag_dict


### PR DESCRIPTION
## Describe your changes

This fixes the telemetry tests to take into account the start event that was removed [this pr on core](https://github.com/ploomber/core/pull/77).

I couldn't get the test `test_install_uses_telemetry` to work local, but it works in the gh-actions. 

## Issue number

Closes #1139

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview ploomber start -->
----
:books: Documentation preview :books:: https://ploomber--1141.org.readthedocs.build/en/1141/

<!-- readthedocs-preview ploomber end -->