### PR TITLE
unpin pycodestyle dependencie

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,9 +175,7 @@ setup(
         # dependencies in jupyter notebooks
         "sqlparse",
         "autopep8",
-        # autopep8 breaks with pycodestyle 2.11.0, so until they update it,
-        # we need to pin this. https://github.com/hhatto/autopep8/issues/689
-        "pycodestyle<2.11.0",
+        "pycodestyle",
         "parso",
         # for generating dag.to_markup(fmt='html')
         "mistune",


### PR DESCRIPTION
## Describe your changes 

The autopep8 [issue](https://github.com/hhatto/autopep8/issues/689) that caused problems with `pycodestyle` was solved. So unpin the `pycodestyle` version on `setup.py`.

## Issue number

Closes #1131

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)



<!-- readthedocs-preview ploomber start -->
----
:books: Documentation preview :books:: https://ploomber--1143.org.readthedocs.build/en/1143/

<!-- readthedocs-preview ploomber end -->