### PR TITLE
Update videos.html to include the Jupyter Con 2023 presentation

### DIFF
--- a/doc/_templates/videos.html
+++ b/doc/_templates/videos.html
@@ -105,6 +105,18 @@
         </div>
         <p>First public presentation (a bit outdated). Describes motivation and brief description (no demo).</p>
     </div> <!-- Col End -->
+
+    <div class="col-lg-4 col-md-6 col-sm-12 m-auto p-3">
+        <!-- Col Start -->
+        <h3>JupyterCon 2023</h3>
+        <div class="video-container">
+            <iframe width="auto" height="auto" margin="1px" padding="2rem"
+                src="https://www.youtube.com/watch?v=rlEy_JoOye0" title="YouTube video player" frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen></iframe>
+        </div>
+        <p>A New Notebook Executor For Running Notebooks in Production.</p>
+    </div> <!-- Col End -->
 </div>
 
 <style>


### PR DESCRIPTION
## Describe your changes
Adding the Jupyter Con from 2023 to the Video section of Ploomber documentation.

## Issue number
https://github.com/ploomber/ploomber/issues/1151

As an aside - the urls in the github pull request template for doing a pull request are no longer valid. (The ones for linting, testing and documenting-changes-and-new-features)






<!-- readthedocs-preview ploomber start -->
----
:books: Documentation preview :books:: https://ploomber--1152.org.readthedocs.build/en/1152/

<!-- readthedocs-preview ploomber end -->