### PR TITLE
allow disabling of static_analysis

### DIFF
--- a/.github/workflows/ci-unit-linux.yml
+++ b/.github/workflows/ci-unit-linux.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.11', '3.12']
     
     services:
       postgres:

--- a/.github/workflows/ci-unit-macos.yml
+++ b/.github/workflows/ci-unit-macos.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.11', '3.12']
 
     steps:
       # https://www.cybertec-postgresql.com/en/postgresql-github-actions-continuous-integration/

--- a/src/ploomber/env/validate.py
+++ b/src/ploomber/env/validate.py
@@ -48,7 +48,7 @@ def no_double_underscores(keys):
 
     if not_allowed:
         raise ValueError(
-            "Keys cannot have double " "underscores, got: {}".format(not_allowed)
+            "Keys cannot have double underscores, got: {}".format(not_allowed)
         )
 
 

--- a/src/ploomber/jupyter/manager.py
+++ b/src/ploomber/jupyter/manager.py
@@ -5,7 +5,7 @@ Module for the jupyter extension
 For debugging:
 >>> from ploomber.jupyter.dag import JupyterDAGManager
 >>> from ploomber.jupyter.manager import derive_class
->>> from jupytext.contentsmanager import TextFileContentsManager
+>>> from jupytext import TextFileContentsManager
 >>> PloomberContentsManager = derive_class(TextFileContentsManager)
 >>> cm = PloomberContentsManager()
 """

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -451,7 +451,7 @@ class NotebookSource(Source):
         if self.static_analysis == "strict":
             self._check_notebook(raise_=True, check_signature=True)
         elif self.static_analysis == "disable":
-	    continue
+            continue
         else:
             # otherwise, only warn on unused parameters
             _warn_on_unused_params(self._nb_obj_unrendered, self._params)

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -450,6 +450,8 @@ class NotebookSource(Source):
         # regular mode: _check_notebook called in .run
         if self.static_analysis == "strict":
             self._check_notebook(raise_=True, check_signature=True)
+        elif self.static_analysis == "disable":
+	    continue
         else:
             # otherwise, only warn on unused parameters
             _warn_on_unused_params(self._nb_obj_unrendered, self._params)

--- a/src/ploomber/sources/notebooksource.py
+++ b/src/ploomber/sources/notebooksource.py
@@ -451,7 +451,7 @@ class NotebookSource(Source):
         if self.static_analysis == "strict":
             self._check_notebook(raise_=True, check_signature=True)
         elif self.static_analysis == "disable":
-            continue
+            return
         else:
             # otherwise, only warn on unused parameters
             _warn_on_unused_params(self._nb_obj_unrendered, self._params)

--- a/src/ploomber/util/validate.py
+++ b/src/ploomber/util/validate.py
@@ -22,6 +22,6 @@ def keys(valid, passed, required=None, name="spec"):
         if missing:
             raise MissingKeysValidationError(
                 f"Error validating {name}. Missing "
-                f"keys: { pretty_print.iterable(missing)}",
+                f"keys: {pretty_print.iterable(missing)}",
                 missing_keys=missing,
             )

--- a/tests/io_mod/test_wcwidth.py
+++ b/tests/io_mod/test_wcwidth.py
@@ -2,6 +2,7 @@ import pytest
 from ploomber.io.wcwidth import wcswidth, wcwidth
 
 
+# fmt: off
 @pytest.mark.parametrize(
     ("c", "expected"),
     [
@@ -17,6 +18,7 @@ from ploomber.io.wcwidth import wcswidth, wcwidth
         ("＄", 2),
     ],
 )
+# fmt: on
 def test_wcwidth(c: str, expected: int) -> None:
     assert wcwidth(c) == expected
 

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -23,7 +23,7 @@ from ploomber.jupyter.manager import derive_class
 from ploomber.jupyter.dag import JupyterDAGManager
 from ploomber.spec import DAGSpec
 
-from jupytext.contentsmanager import TextFileContentsManager
+from jupytext import TextFileContentsManager
 
 PloomberContentsManager = derive_class(TextFileContentsManager)
 


### PR DESCRIPTION
## Describe your changes
This change would allow users to specify that they would like to disable unnecessary warnings related to the global parameters not being used in every notebook run with NotebookRunner. Note that `disable` is already a [valid option for `static_analysis`](https://github.com/TeaganKing/ploomber/blob/536c8265b024a0b152745d268ec7b540e9f11ed9/src/ploomber/sources/notebooksource.py#L251).

Closes #1175


<!-- readthedocs-preview ploomber start -->
----
📚 Documentation preview 📚: https://ploomber--1176.org.readthedocs.build/en/1176/

<!-- readthedocs-preview ploomber end -->